### PR TITLE
Implement the `call_v` style interfaces.

### DIFF
--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -8,27 +8,52 @@ class RedisClient
     class Pipeline
       ReplySizeError = Class.new(::RedisClient::Error)
 
-      def initialize(router)
+      def initialize(router, command_builder)
         @router = router
+        @command_builder = command_builder
         @grouped = Hash.new([].freeze)
         @size = 0
       end
 
-      def call(*command, **kwargs)
-        node_key = @router.find_node_key(*command, primary_only: true, **kwargs)
-        @grouped[node_key] += [[@size, :call, command, kwargs]]
+      def call(*args, **kwargs)
+        command = @command_builder.generate(args, kwargs)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :call_v, command]]
         @size += 1
       end
 
-      def call_once(*command, **kwargs)
-        node_key = @router.find_node_key(*command, primary_only: true, **kwargs)
-        @grouped[node_key] += [[@size, :call_once, command, kwargs]]
+      def call_v(args)
+        command = @command_builder.generate(args)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :call_v, command]]
         @size += 1
       end
 
-      def blocking_call(timeout, *command, **kwargs)
-        node_key = @router.find_node_key(*command, primary_only: true, **kwargs)
-        @grouped[node_key] += [[@size, :blocking_call, timeout, command, kwargs]]
+      def call_once(*args, **kwargs)
+        command = @command_builder.generate(args, kwargs)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :call_once_v, command]]
+        @size += 1
+      end
+
+      def call_once_v(args)
+        command = @command_builder.generate(args)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :call_once_v, command]]
+        @size += 1
+      end
+
+      def blocking_call(timeout, *args, **kwargs)
+        command = @command_builder.generate(args, kwargs)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command]]
+        @size += 1
+      end
+
+      def blocking_call_v(timeout, args)
+        command = @command_builder.generate(args)
+        node_key = @router.find_node_key(command, primary_only: true)
+        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command]]
         @size += 1
       end
 
@@ -37,20 +62,15 @@ class RedisClient
       end
 
       # TODO: https://github.com/redis-rb/redis-cluster-client/issues/37 handle redirections
-      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         all_replies = Array.new(@size)
         errors = {}
         threads = @grouped.map do |k, v|
           Thread.new(@router, k, v) do |router, node_key, rows|
             Thread.pass
             replies = router.find_node(node_key).pipelined do |pipeline|
-              rows.each do |row|
-                case row[1]
-                when :call then pipeline.call(*row[2], **row[3])
-                when :call_once then pipeline.call_once(*row[2], **row[3])
-                when :blocking_call then pipeline.blocking_call(row[2], *row[3], **row[4])
-                else raise NotImplementedError, row[1]
-                end
+              rows.each do |(_size, *row)|
+                pipeline.send(*row)
               end
             end
 

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -15,45 +15,45 @@ class RedisClient
         @size = 0
       end
 
-      def call(*args, **kwargs)
+      def call(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :call_v, command]]
+        @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
-      def call_v(args)
+      def call_v(args, &block)
         command = @command_builder.generate(args)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :call_v, command]]
+        @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
-      def call_once(*args, **kwargs)
+      def call_once(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :call_once_v, command]]
+        @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
-      def call_once_v(args)
+      def call_once_v(args, &block)
         command = @command_builder.generate(args)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :call_once_v, command]]
+        @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
-      def blocking_call(timeout, *args, **kwargs)
+      def blocking_call(timeout, *args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command]]
+        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end
 
-      def blocking_call_v(timeout, args)
+      def blocking_call_v(timeout, args, &block)
         command = @command_builder.generate(args)
         node_key = @router.find_node_key(command, primary_only: true)
-        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command]]
+        @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end
 
@@ -69,8 +69,8 @@ class RedisClient
           Thread.new(@router, k, v) do |router, node_key, rows|
             Thread.pass
             replies = router.find_node(node_key).pipelined do |pipeline|
-              rows.each do |(_size, *row)|
-                pipeline.send(*row)
+              rows.each do |(_size, *row, block)|
+                pipeline.send(*row, &block)
               end
             end
 

--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -3,15 +3,24 @@
 class RedisClient
   class Cluster
     class PubSub
-      def initialize(router)
+      def initialize(router, command_builder)
         @router = router
+        @command_builder = command_builder
         @pubsub = nil
       end
 
-      def call(*command, **kwargs)
+      def call(*args, **kwargs)
         close
-        @pubsub = @router.assign_node(*command, **kwargs).pubsub
-        @pubsub.call(*command, **kwargs)
+        command = @command_builder.generate(args, kwargs)
+        @pubsub = @router.assign_node(command).pubsub
+        @pubsub.call_v(command)
+      end
+
+      def call_v(command)
+        close
+        command = @command_builder.generate(command)
+        @pubsub = @router.assign_node(command).pubsub
+        @pubsub.call_v(command)
       end
 
       def close

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -243,27 +243,27 @@ class RedisClient
 
       def test_call_all
         want = (1..(@test_node_info.count { |info| info[:role] == 'master' })).map { |_| 'PONG' }
-        got = @test_node.call_all(:call, 'PING')
+        got = @test_node.call_all(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: primary only')
 
         want = (1..(@test_node_info.count)).map { |_| 'PONG' }
-        got = @test_node_with_scale_read.call_all(:call, 'PING')
+        got = @test_node_with_scale_read.call_all(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: scale read')
       end
 
       def test_call_primaries
         want = (1..(@test_node_info.count { |info| info[:role] == 'master' })).map { |_| 'PONG' }
-        got = @test_node.call_primaries(:call, 'PING')
+        got = @test_node.call_primaries(:call_v, ['PING'], [])
         assert_equal(want, got)
       end
 
       def test_call_replicas
         want = (1..(@test_node_info.count { |info| info[:role] == 'master' })).map { |_| 'PONG' }
 
-        got = @test_node.call_replicas(:call, 'PING')
+        got = @test_node.call_replicas(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: primary only')
 
-        got = @test_node_with_scale_read.call_replicas(:call, 'PING')
+        got = @test_node_with_scale_read.call_replicas(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: scale read')
       end
 

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -12,7 +12,7 @@ class RedisClient
       end
 
       def teardown
-        @client.call('FLUSHDB')
+        @client&.call('FLUSHDB')
         wait_for_replication
         @client&.close
       end


### PR DESCRIPTION
Counterpart to https://github.com/redis-rb/redis-client/commit/ef44f0862a186293f0c56213f828ad7a19f09418.

That's the interface `redis-rb` will use, as it avoid splating arguments all the time. It also happens to simplify `redis-cluster-client` IMO.

