### PR TITLE
Expose #config to allow accessing read_timeout

### DIFF
--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -8,7 +8,10 @@ class RedisClient
   class Cluster
     ZERO_CURSOR_FOR_SCAN = '0'
 
+    attr_reader :config
+
     def initialize(config, pool: nil, **kwargs)
+      @config = config
       @router = ::RedisClient::Cluster::Router.new(config, pool: pool, **kwargs)
       @command_builder = config.command_builder
     end

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -20,7 +20,7 @@ class RedisClient
 
     InvalidClientConfigError = Class.new(::RedisClient::Error)
 
-    attr_reader :command_builder
+    attr_reader :command_builder, :client_config
 
     def initialize(nodes: DEFAULT_NODES, replica: false, client_implementation: Cluster, fixed_hostname: '', **client_config)
       @replica = true & replica
@@ -35,6 +35,10 @@ class RedisClient
 
     def inspect
       "#<#{self.class.name} #{per_node_key.values}>"
+    end
+
+    def read_timeout
+      @client_config[:read_timeout] || @client_config[:timeout] || RedisClient::Config::DEFAULT_TIMEOUT
     end
 
     def new_pool(size: 5, timeout: 5, **kwargs)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -17,6 +17,11 @@ class RedisClient
         @client&.close
       end
 
+      def test_config
+        refute_nil @client.config
+        refute_nil @client.config.read_timeout
+      end
+
       def test_inspect
         assert_match(/^#<RedisClient::Cluster [0-9., :]*>$/, @client.inspect)
       end


### PR DESCRIPTION
It's needed by redis-rb for blocking commands