### PR TITLE
feat: add replica affinity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ gem 'redis-cluster-client'
 | --- | --- | --- | --- |
 | `:nodes` | String or Hash or Array<String, Hash> | `['redis://127.0.0.1:6379']` | node addresses for startup connection |
 | `:replica` | Boolean | `false` | `true` if client should use scale read feature |
+| `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random` or `:nearest` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
@@ -34,6 +35,10 @@ RedisClient.cluster.new_client
 
 # To connect to all nodes to use scale reading feature
 RedisClient.cluster(replica: true).new_client
+#=> #<RedisClient::Cluster 172.20.0.2:6379, 172.20.0.3:6379, 172.20.0.4:6379, 172.20.0.5:6379, 172.20.0.6:6379, 172.20.0.7:6379>
+
+# To connect to all nodes to use scale reading feature prioritizing low-latency replicas
+RedisClient.cluster(replica: true, replica_affinity: :nearest).new_client
 #=> #<RedisClient::Cluster 172.20.0.2:6379, 172.20.0.3:6379, 172.20.0.4:6379, 172.20.0.5:6379, 172.20.0.6:6379, 172.20.0.7:6379>
 
 # With generic options for redis-client

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem 'redis-cluster-client'
 | --- | --- | --- | --- |
 | `:nodes` | String or Hash or Array<String, Hash> | `['redis://127.0.0.1:6379']` | node addresses for startup connection |
 | `:replica` | Boolean | `false` | `true` if client should use scale read feature |
-| `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random` or `:nearest` are valid |
+| `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random` or `:latency` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
@@ -38,7 +38,7 @@ RedisClient.cluster(replica: true).new_client
 #=> #<RedisClient::Cluster 172.20.0.2:6379, 172.20.0.3:6379, 172.20.0.4:6379, 172.20.0.5:6379, 172.20.0.6:6379, 172.20.0.7:6379>
 
 # To connect to all nodes to use scale reading feature prioritizing low-latency replicas
-RedisClient.cluster(replica: true, replica_affinity: :nearest).new_client
+RedisClient.cluster(replica: true, replica_affinity: :latency).new_client
 #=> #<RedisClient::Cluster 172.20.0.2:6379, 172.20.0.3:6379, 172.20.0.4:6379, 172.20.0.5:6379, 172.20.0.6:6379, 172.20.0.7:6379>
 
 # With generic options for redis-client

--- a/Rakefile
+++ b/Rakefile
@@ -45,3 +45,14 @@ task :wait do
     **TEST_GENERIC_OPTIONS
   ).wait_for_cluster_to_be_ready
 end
+
+desc 'Build cluster'
+task :build_cluster do
+  $LOAD_PATH.unshift(File.expand_path('test', __dir__))
+  require 'cluster_controller'
+  hosts = ARGV[1..]
+  ports = (6379..6384)
+  shards = 3
+  nodes = hosts.product(ports).map { |host, port| "redis://#{host}:#{port}" }
+  ::ClusterController.new(nodes, replica_size: (nodes.size / shards) - 1).rebuild
+end

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ task :build_cluster do
   $LOAD_PATH.unshift(File.expand_path('test', __dir__))
   require 'cluster_controller'
   hosts = ARGV[1..]
-  ports = (6379..6384)
+  ports = (6379..6384).to_a
   shards = 3
   nodes = hosts.product(ports).map { |host, port| "redis://#{host}:#{port}" }
   ::ClusterController.new(nodes, replica_size: (nodes.size / shards) - 1).rebuild

--- a/docker-compose.nat.yaml
+++ b/docker-compose.nat.yaml
@@ -5,14 +5,15 @@ services:
     image: "redis:${REDIS_VERSION:-7}"
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6379
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6379
+      --cluster-announce-bus-port 16379
     restart: "${RESTART_POLICY:-always}"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -21,73 +22,84 @@ services:
       retries: 10
     ports:
       - "6379:6379"
+      - "16379:16379"
   node2:
     <<: *node
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6380
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6380
+      --cluster-announce-bus-port 16380
     ports:
       - "6380:6379"
+      - "16380:16379"
   node3:
     <<: *node
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6381
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6381
+      --cluster-announce-bus-port 16381
     ports:
       - "6381:6379"
+      - "16381:16379"
   node4:
     <<: *node
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6382
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6382
+      --cluster-announce-bus-port 16382
     ports:
       - "6382:6379"
+      - "16382:16379"
   node5:
     <<: *node
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6383
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6383
+      --cluster-announce-bus-port 16383
     ports:
       - "6383:6379"
+      - "16383:16379"
   node6:
     <<: *node
     command: >
       redis-server
-      --maxmemory             64mb
-      --maxmemory-policy      allkeys-lru
-      --appendonly            yes
-      --cluster-enabled       yes
-      --cluster-config-file   nodes.conf
-      --cluster-node-timeout  5000
-      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
-      --cluster-announce-port 6384
+      --maxmemory                 64mb
+      --maxmemory-policy          allkeys-lru
+      --appendonly                yes
+      --cluster-enabled           yes
+      --cluster-config-file       nodes.conf
+      --cluster-node-timeout      5000
+      --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port     6384
+      --cluster-announce-bus-port 16384
     ports:
       - "6384:6379"
+      - "16384:16379"

--- a/docker-compose.nat.yaml
+++ b/docker-compose.nat.yaml
@@ -10,7 +10,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6379
       --cluster-announce-bus-port 16379
@@ -32,7 +32,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6380
       --cluster-announce-bus-port 16380
@@ -48,7 +48,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6381
       --cluster-announce-bus-port 16381
@@ -64,7 +64,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6382
       --cluster-announce-bus-port 16382
@@ -80,7 +80,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6383
       --cluster-announce-bus-port 16383
@@ -96,7 +96,7 @@ services:
       --appendonly                yes
       --cluster-enabled           yes
       --cluster-config-file       nodes.conf
-      --cluster-node-timeout      5000
+      --cluster-node-timeout      30000
       --cluster-announce-ip       "${REDIS_HOST:-127.0.0.1}"
       --cluster-announce-port     6384
       --cluster-announce-bus-port 16384

--- a/docker-compose.nat.yaml
+++ b/docker-compose.nat.yaml
@@ -1,0 +1,93 @@
+---
+# REDIS_HOST=192.168.11.9 docker compose -f docker-compose.nat.yaml ps
+services:
+  node1: &node
+    image: "redis:${REDIS_VERSION:-7}"
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6379
+    restart: "${RESTART_POLICY:-always}"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: "7s"
+      timeout: "5s"
+      retries: 10
+    ports:
+      - "6379:6379"
+  node2:
+    <<: *node
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6380
+    ports:
+      - "6380:6379"
+  node3:
+    <<: *node
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6381
+    ports:
+      - "6381:6379"
+  node4:
+    <<: *node
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6382
+    ports:
+      - "6382:6379"
+  node5:
+    <<: *node
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6383
+    ports:
+      - "6383:6379"
+  node6:
+    <<: *node
+    command: >
+      redis-server
+      --maxmemory             64mb
+      --maxmemory-policy      allkeys-lru
+      --appendonly            yes
+      --cluster-enabled       yes
+      --cluster-config-file   nodes.conf
+      --cluster-node-timeout  5000
+      --cluster-announce-ip   "${REDIS_HOST:-127.0.0.1}"
+      --cluster-announce-port 6384
+    ports:
+      - "6384:6379"

--- a/docs/class_diagrams_redis_cluster_client.md
+++ b/docs/class_diagrams_redis_cluster_client.md
@@ -73,7 +73,7 @@ classDiagram
     +find_node_key_of_replica()
   }
 
-  class RedisClient_Cluster_Node_NearestReplica {
+  class RedisClient_Cluster_Node_LatencyReplica {
     +replica_clients()
     +find_node_key_of_replica()
   }
@@ -131,8 +131,8 @@ classDiagram
   RedisClient_Cluster_Router ..> module_RedisClient_Cluster_NodeKey : call
 
   RedisClient_Cluster_Node_RandomReplica ..|> module_RedisClient_Cluster_Node_ReplicaMixin : include
-  RedisClient_Cluster_Node_NearestReplica ..|> module_RedisClient_Cluster_Node_ReplicaMixin : include
+  RedisClient_Cluster_Node_LatencyReplica ..|> module_RedisClient_Cluster_Node_ReplicaMixin : include
   RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_PrimaryOnly : new
   RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_RandomReplica : new
-  RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_NearestReplica : new
+  RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_LatencyReplica : new
 ```

--- a/docs/class_diagrams_redis_cluster_client.md
+++ b/docs/class_diagrams_redis_cluster_client.md
@@ -51,11 +51,39 @@ classDiagram
     +call_primaries()
     +call_replicas()
     +send_ping()
-    +scale_reading_clients()
+    +clients_for_scanning()
     +find_node_key_of_primary()
     +find_node_key_of_replica()
     +update_slot()
     +replicated?()
+  }
+
+  class RedisClient_Cluster_Node_PrimaryOnly {
+    +clients()
+    +primary_node_keys()
+    +replica_node_keys()
+    +fixed_clients()
+    +primary_clients()
+    +replica_clients()
+    +find_node_key_of_replica()
+  }
+
+  class RedisClient_Cluster_Node_RandomReplica {
+    +replica_clients()
+    +find_node_key_of_replica()
+  }
+
+  class RedisClient_Cluster_Node_NearestReplica {
+    +replica_clients()
+    +find_node_key_of_replica()
+  }
+
+  class module_RedisClient_Cluster_Node_ReplicaMixin {
+    +clients()
+    +primary_node_keys()
+    +replica_node_keys()
+    +fixed_clients()
+    +primary_clients()
   }
 
   class module_RedisClient_Cluster_NodeKey {
@@ -101,4 +129,10 @@ classDiagram
   RedisClient_Cluster_Router ..> RedisClient_Cluster_Command : new
   RedisClient_Cluster_Router ..> module_RedisClient_Cluster_KeySlotConverter : call
   RedisClient_Cluster_Router ..> module_RedisClient_Cluster_NodeKey : call
+
+  RedisClient_Cluster_Node_RandomReplica ..|> module_RedisClient_Cluster_Node_ReplicaMixin : include
+  RedisClient_Cluster_Node_NearestReplica ..|> module_RedisClient_Cluster_Node_ReplicaMixin : include
+  RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_PrimaryOnly : new
+  RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_RandomReplica : new
+  RedisClient_Cluster_Node ..> RedisClient_Cluster_Node_NearestReplica : new
 ```

--- a/docs/class_diagrams_redis_cluster_client.md
+++ b/docs/class_diagrams_redis_cluster_client.md
@@ -62,7 +62,7 @@ classDiagram
     +clients()
     +primary_node_keys()
     +replica_node_keys()
-    +fixed_clients()
+    +clients_for_scanning()
     +primary_clients()
     +replica_clients()
     +find_node_key_of_replica()
@@ -82,7 +82,7 @@ classDiagram
     +clients()
     +primary_node_keys()
     +replica_node_keys()
-    +fixed_clients()
+    +clients_for_scanning()
     +primary_clients()
   }
 

--- a/docs/class_diagrams_redis_cluster_client.md
+++ b/docs/class_diagrams_redis_cluster_client.md
@@ -44,8 +44,6 @@ classDiagram
     +each()
     +sample()
     +node_keys()
-    +primary_node_keys()
-    +replica_node_keys()
     +find_by()
     +call_all()
     +call_primaries()
@@ -54,36 +52,39 @@ classDiagram
     +clients_for_scanning()
     +find_node_key_of_primary()
     +find_node_key_of_replica()
+    +any_primary_node_key()
+    +any_replica_node_key()
     +update_slot()
-    +replicated?()
   }
 
   class RedisClient_Cluster_Node_PrimaryOnly {
     +clients()
-    +primary_node_keys()
-    +replica_node_keys()
-    +clients_for_scanning()
     +primary_clients()
     +replica_clients()
+    +clients_for_scanning()
     +find_node_key_of_replica()
+    +any_primary_node_key()
+    +any_replica_node_key()
   }
 
   class RedisClient_Cluster_Node_RandomReplica {
     +replica_clients()
+    +clients_for_scanning()
     +find_node_key_of_replica()
+    +any_replica_node_key()
   }
 
   class RedisClient_Cluster_Node_LatencyReplica {
     +replica_clients()
+    +clients_for_scanning()
     +find_node_key_of_replica()
+    +any_replica_node_key()
   }
 
   class module_RedisClient_Cluster_Node_ReplicaMixin {
     +clients()
-    +primary_node_keys()
-    +replica_node_keys()
-    +clients_for_scanning()
     +primary_clients()
+    +any_primary_node_key()
   }
 
   class module_RedisClient_Cluster_NodeKey {

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -53,9 +53,10 @@ class RedisClient
     def scan(*args, **kwargs, &block)
       raise ArgumentError, 'block required' unless block
 
+      random = Random.new
       cursor = ZERO_CURSOR_FOR_SCAN
       loop do
-        cursor, keys = @router.scan('SCAN', cursor, *args, **kwargs)
+        cursor, keys = @router.scan('SCAN', cursor, *args, random: random, **kwargs)
         keys.each(&block)
         break if cursor == ZERO_CURSOR_FOR_SCAN
       end

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -53,10 +53,10 @@ class RedisClient
     def scan(*args, **kwargs, &block)
       raise ArgumentError, 'block required' unless block
 
-      random = Random.new
+      seed = Random.new_seed
       cursor = ZERO_CURSOR_FOR_SCAN
       loop do
-        cursor, keys = @router.scan('SCAN', cursor, *args, random: random, **kwargs)
+        cursor, keys = @router.scan('SCAN', cursor, *args, seed: seed, **kwargs)
         keys.each(&block)
         break if cursor == ZERO_CURSOR_FOR_SCAN
       end

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -5,7 +5,7 @@ require 'redis_client/config'
 require 'redis_client/cluster/errors'
 require 'redis_client/cluster/node/primary_only'
 require 'redis_client/cluster/node/random_replica'
-require 'redis_client/cluster/node/nearest_replica'
+require 'redis_client/cluster/node/latency_replica'
 
 class RedisClient
   class Cluster
@@ -188,8 +188,8 @@ class RedisClient
       def make_topology_class(with_replica, replica_affinity)
         if with_replica && replica_affinity == :random
           ::RedisClient::Cluster::Node::RandomReplica
-        elsif with_replica && replica_affinity == :nearest
-          ::RedisClient::Cluster::Node::NearestReplica
+        elsif with_replica && replica_affinity == :latency
+          ::RedisClient::Cluster::Node::LatencyReplica
         else
           ::RedisClient::Cluster::Node::PrimaryOnly
         end

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -92,11 +92,18 @@ class RedisClient
         end
       end
 
-      def initialize(options, node_info: [], pool: nil, with_replica: false, **kwargs)
-        @with_replica = with_replica
+      def initialize( # rubocop:disable Metrics/ParameterLists
+        options,
+        node_info: [],
+        with_replica: false,
+        replica_affinity: :random,
+        pool: nil,
+        **kwargs
+      )
+
         @slots = build_slot_node_mappings(node_info)
         @replications = build_replication_mappings(node_info)
-        @clients = build_clients(options, pool: pool, **kwargs)
+        @topology = make_topology_class(with_replica, replica_affinity).new(@replications, options, pool, **kwargs)
         @mutex = Mutex.new
       end
 
@@ -105,87 +112,54 @@ class RedisClient
       end
 
       def each(&block)
-        @clients.each_value(&block)
+        @topology.clients.each_value(&block)
       end
 
       def sample
-        @clients.values.sample
+        @topology.clients.values.sample
       end
 
       def node_keys
-        @clients.keys.sort
+        @topology.clients.keys.sort
       end
 
       def primary_node_keys
-        @clients.filter_map { |k, _| primary?(k) ? k : nil }.sort
+        @topology.primary_node_keys
       end
 
       def replica_node_keys
-        return primary_node_keys if replica_disabled?
-
-        @clients.filter_map { |k, _| replica?(k) ? k : nil }.sort
+        @topology.replica_node_keys
       end
 
       def find_by(node_key)
-        raise ReloadNeeded if node_key.nil? || !@clients.key?(node_key)
+        raise ReloadNeeded if node_key.nil? || !@topology.clients.key?(node_key)
 
-        @clients.fetch(node_key)
+        @topology.clients.fetch(node_key)
       end
 
       def call_all(method, command, args, &block)
-        results, errors = try_map do |_, client|
-          client.send(method, *args, command, &block)
-        end
-
-        return results.values if errors.empty?
-
-        raise ::RedisClient::Cluster::ErrorCollection, errors
+        call_multiple_nodes!(@topology.clients, method, command, args, &block)
       end
 
       def call_primaries(method, command, args, &block)
-        results, errors = try_map do |node_key, client|
-          next if replica?(node_key)
-
-          client.send(method, *args, command, &block)
-        end
-
-        return results.values if errors.empty?
-
-        raise ::RedisClient::Cluster::ErrorCollection, errors
+        call_multiple_nodes!(@topology.primary_clients, method, command, args, &block)
       end
 
       def call_replicas(method, command, args, &block)
-        return call_primaries(method, command, args, &block) if replica_disabled?
-
-        replica_node_keys = @replications.values.map(&:sample)
-        results, errors = try_map do |node_key, client|
-          next if primary?(node_key) || !replica_node_keys.include?(node_key)
-
-          client.send(method, *args, command, &block)
-        end
-
-        return results.values if errors.empty?
-
-        raise ::RedisClient::Cluster::ErrorCollection, errors
+        call_multiple_nodes!(@topology.replica_clients, method, command, args, &block)
       end
 
       def send_ping(method, command, args, &block)
-        results, errors = try_map do |_, client|
-          client.send(method, *args, command, &block)
-        end
-
-        return results.values if errors.empty?
+        result_values, errors = call_multiple_nodes(@topology.elients, method, command, args, &block)
+        return result_values if errors.empty?
 
         raise ReloadNeeded if errors.values.any?(::RedisClient::ConnectionError)
 
         raise ::RedisClient::Cluster::ErrorCollection, errors
       end
 
-      def scale_reading_clients
-        keys = replica_disabled? ? @replications.keys : @replications.values.map(&:first)
-        @clients.select { |k, _| keys.include?(k) }.values.sort_by do |client|
-          "#{client.config.host}-#{client.config.port}"
-        end
+      def clients_for_scanning
+        @topology.fixed_clients.values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
       end
 
       def find_node_key_of_primary(slot)
@@ -198,40 +172,23 @@ class RedisClient
       end
 
       def find_node_key_of_replica(slot)
-        return if slot.nil?
-
-        slot = Integer(slot)
-        return if slot < MIN_SLOT || slot > MAX_SLOT
-
-        return @slots[slot] if replica_disabled? || @replications[@slots[slot]].size.zero?
-
-        @replications[@slots[slot]].sample
+        @topology.find_node_key_of_replica(find_node_key_of_primary(slot))
       end
 
       def update_slot(slot, node_key)
         @mutex.synchronize { @slots[slot] = node_key }
       end
 
-      def replicated?(primary_node_key, replica_node_key)
-        return false if @replications.nil? || @replications.size.zero?
-
-        @replications.fetch(primary_node_key).include?(replica_node_key)
-      end
-
       private
 
-      def replica_disabled?
-        !@with_replica
-      end
-
-      def primary?(node_key)
-        !replica?(node_key)
-      end
-
-      def replica?(node_key)
-        return false if @replications.nil? || @replications.size.zero?
-
-        !@replications.key?(node_key)
+      def make_topology_class(with_replica, replica_affinity)
+        if with_replica && replica_affinity == :random
+          ::RedisClient::Cluster::Node::RandomReplica
+        elsif with_replica && replica_affinity == :nearest
+          ::RedisClient::Cluster::Node::NearestReplica
+        else
+          ::RedisClient::Cluster::Node::PrimaryOnly
+        end
       end
 
       def build_slot_node_mappings(node_info)
@@ -254,24 +211,25 @@ class RedisClient
         end
       end
 
-      def build_clients(options, pool: nil, **kwargs)
-        options.filter_map do |node_key, option|
-          next if replica_disabled? && replica?(node_key)
+      def call_multiple_nodes(clients, method, command, args, &block)
+        results, errors = try_map(clients) do |_, client|
+          client.send(method, *args, command, &block)
+        end
 
-          config = ::RedisClient::Cluster::Node::Config.new(
-            scale_read: replica?(node_key),
-            **option.merge(kwargs.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
-          )
-          client = pool.nil? ? config.new_client : config.new_pool(**pool)
-
-          [node_key, client]
-        end.to_h
+        [results.values, errors]
       end
 
-      def try_map # rubocop:disable Metrics/MethodLength
+      def call_multiple_nodes!(clients, method, command, args, &block)
+        result_values, errors = call_multiple_nodes(clients, method, command, args, &block)
+        return result_values if errors.empty?
+
+        raise ::RedisClient::Cluster::ErrorCollection, errors
+      end
+
+      def try_map(clients) # rubocop:disable Metrics/MethodLength
         results = {}
         errors = {}
-        @clients.each_slice(MAX_THREADS * 2) do |chuncked_clients|
+        clients.each_slice(MAX_THREADS * 2) do |chuncked_clients|
           threads = chuncked_clients.map do |k, v|
             Thread.new(k, v) do |node_key, client|
               Thread.pass

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -127,14 +127,6 @@ class RedisClient
         @topology.clients.keys.sort
       end
 
-      def primary_node_keys
-        @topology.primary_node_keys
-      end
-
-      def replica_node_keys
-        @topology.replica_node_keys
-      end
-
       def find_by(node_key)
         raise ReloadNeeded if node_key.nil? || !@topology.clients.key?(node_key)
 
@@ -162,8 +154,8 @@ class RedisClient
         raise ::RedisClient::Cluster::ErrorCollection, errors
       end
 
-      def clients_for_scanning
-        @topology.clients_for_scanning.values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
+      def clients_for_scanning(random: Random)
+        @topology.clients_for_scanning(random: random).values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
       end
 
       def find_node_key_of_primary(slot)
@@ -175,8 +167,16 @@ class RedisClient
         @slots[slot]
       end
 
-      def find_node_key_of_replica(slot)
-        @topology.find_node_key_of_replica(find_node_key_of_primary(slot))
+      def find_node_key_of_replica(slot, random: Random)
+        @topology.find_node_key_of_replica(find_node_key_of_primary(slot), random: random)
+      end
+
+      def any_primary_node_key(random: Random)
+        @topology.any_primary_node_key(random: random)
+      end
+
+      def any_replica_node_key(random: Random)
+        @topology.any_replica_node_key(random: random)
       end
 
       def update_slot(slot, node_key)

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -55,6 +55,7 @@ class RedisClient
                 cli&.close
               end
             end
+
             threads.each(&:join)
           end
 

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -154,8 +154,8 @@ class RedisClient
         raise ::RedisClient::Cluster::ErrorCollection, errors
       end
 
-      def clients_for_scanning(random: Random)
-        @topology.clients_for_scanning(random: random).values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
+      def clients_for_scanning(seed: nil)
+        @topology.clients_for_scanning(seed: seed).values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
       end
 
       def find_node_key_of_primary(slot)
@@ -167,16 +167,16 @@ class RedisClient
         @slots[slot]
       end
 
-      def find_node_key_of_replica(slot, random: Random)
-        @topology.find_node_key_of_replica(find_node_key_of_primary(slot), random: random)
+      def find_node_key_of_replica(slot, seed: nil)
+        @topology.find_node_key_of_replica(find_node_key_of_primary(slot), seed: seed)
       end
 
-      def any_primary_node_key(random: Random)
-        @topology.any_primary_node_key(random: random)
+      def any_primary_node_key(seed: nil)
+        @topology.any_primary_node_key(seed: seed)
       end
 
-      def any_replica_node_key(random: Random)
-        @topology.any_replica_node_key(random: random)
+      def any_replica_node_key(seed: nil)
+        @topology.any_replica_node_key(seed: seed)
       end
 
       def update_slot(slot, node_key)

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -3,6 +3,9 @@
 require 'redis_client'
 require 'redis_client/config'
 require 'redis_client/cluster/errors'
+require 'redis_client/cluster/node/primary_only'
+require 'redis_client/cluster/node/random_replica'
+require 'redis_client/cluster/node/nearest_replica'
 
 class RedisClient
   class Cluster

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -168,7 +168,8 @@ class RedisClient
       end
 
       def find_node_key_of_replica(slot, seed: nil)
-        @topology.find_node_key_of_replica(find_node_key_of_primary(slot), seed: seed)
+        primary_node_key = find_node_key_of_primary(slot)
+        @topology.find_node_key_of_replica(primary_node_key, seed: seed)
       end
 
       def any_primary_node_key(seed: nil)

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -153,7 +153,7 @@ class RedisClient
       end
 
       def send_ping(method, command, args, &block)
-        result_values, errors = call_multiple_nodes(@topology.elients, method, command, args, &block)
+        result_values, errors = call_multiple_nodes(@topology.clients, method, command, args, &block)
         return result_values if errors.empty?
 
         raise ReloadNeeded if errors.values.any?(::RedisClient::ConnectionError)
@@ -162,7 +162,7 @@ class RedisClient
       end
 
       def clients_for_scanning
-        @topology.fixed_clients.values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
+        @topology.clients_for_scanning.values.sort_by { |c| "#{c.config.host}-#{c.config.port}" }
       end
 
       def find_node_key_of_primary(slot)

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -42,7 +42,7 @@ class RedisClient
 
           clients.each_slice(::RedisClient::Cluster::Node::MAX_THREADS * 2) do |chuncked_clients|
             threads = chuncked_clients.map do |k, v|
-              Thraed.new(k, v) do |node_key, client|
+              Thread.new(k, v) do |node_key, client|
                 Thread.pass
                 starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
                 client.send(:call_once, 'PING')

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -22,15 +22,16 @@ class RedisClient
           @clients_for_scanning = select_clients_for_scanning(@replications, @clients)
         end
 
-        def clients_for_scanning(random: Random) # rubocop:disable Lint/UnusedMethodArgument
+        def clients_for_scanning(seed: nil) # rubocop:disable Lint/UnusedMethodArgument
           @clients_for_scanning
         end
 
-        def find_node_key_of_replica(primary_node_key, random: Random) # rubocop:disable Lint/UnusedMethodArgument
+        def find_node_key_of_replica(primary_node_key, seed: nil) # rubocop:disable Lint/UnusedMethodArgument
           @replications.fetch(primary_node_key, EMPTY_ARRAY).first || primary_node_key
         end
 
-        def any_replica_node_key(random: Random)
+        def any_replica_node_key(seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           @replications.reject { |_, v| v.empty? }.values.sample(random: random).first
         end
 

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -5,7 +5,7 @@ require 'redis_client/cluster/node/replica_mixin'
 class RedisClient
   class Cluster
     class Node
-      class NearestReplica
+      class LatencyReplica
         include ::RedisClient::Cluster::Node::ReplicaMixin
 
         attr_reader :replica_clients, :clients_for_scanning

--- a/lib/redis_client/cluster/node/nearest_replica.rb
+++ b/lib/redis_client/cluster/node/nearest_replica.rb
@@ -18,9 +18,7 @@ class RedisClient
           all_replica_clients = @clients.select { |k, _| @replica_node_keys.include?(k) }
           latencies = measure_latencies(all_replica_clients)
           @replications.each_value { |keys| keys.sort_by! { |k| latencies.fetch(k) } }
-
-          first_keys = @replications.values.map(&:first)
-          @clients_for_scanning = @replica_clients = @clients.select { |k, _| first_keys.include?(k) }
+          @clients_for_scanning = @replica_clients = select_first_clients(@replications, @clients)
         end
 
         def find_node_key_of_replica(primary_node_key)

--- a/lib/redis_client/cluster/node/nearest_replica.rb
+++ b/lib/redis_client/cluster/node/nearest_replica.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'redis_client/cluster/node/replica_mixin'
+
 class RedisClient
   class Cluster
     class Node

--- a/lib/redis_client/cluster/node/nearest_replica.rb
+++ b/lib/redis_client/cluster/node/nearest_replica.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    class Node
+      class NearestReplica
+        include ::RedisClient::Cluster::Node::ReplicaMixin
+
+        attr_reader :replica_clients
+
+        DUMMY_LATENCY_SEC = 100.0
+
+        def initialize(replications, options, pool, **kwargs)
+          super
+
+          all_replica_clients = @clients.select { |k, _| @replica_node_keys.include?(k) }
+          @latencies = measure_latency_of_replicas(all_replica_clients)
+
+          nearest_replica_keys = @replications.values.map do |replica_node_keys|
+            replica_node_keys.min_by { |k| @latencies.fetch(k) }
+          end
+
+          @replica_clients = @clients.select { |k, _| nearest_replica_keys.include?(k) }
+        end
+
+        def find_node_key_of_replica(primary_node_key)
+          @replications[primary_node_key].min_by { |replica_node_key| @latencies.fetch(replica_node_key) }
+        end
+
+        private
+
+        def measure_latency_of_replicas(clients) # rubocop:disable Metrics/MethodLength
+          latencies = {}
+
+          clients.each_slice(::RedisClient::Cluster::Node::MAX_THREADS * 2) do |chuncked_clients|
+            threads = chuncked_clients.map do |k, v|
+              Thraed.new(k, v) do |node_key, client|
+                Thread.pass
+                starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                client.send(:call_once, 'PING')
+                ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                latencies[node_key] = ending - starting
+              rescue StandardError
+                latencies[node_key] = DUMMY_LATENCY_SEC
+              end
+            end
+
+            threads.each(&:join)
+          end
+
+          latencies
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -4,23 +4,29 @@ class RedisClient
   class Cluster
     class Node
       class PrimaryOnly
-        attr_reader :clients, :primary_node_keys
+        attr_reader :clients
 
         def initialize(replications, options, pool, **kwargs)
-          @replications = replications
-          @primary_node_keys = @replications.keys.sort
-
+          @primary_node_keys = replications.keys.sort
           @clients = build_clients(@primary_node_keys, options, pool, **kwargs)
         end
 
-        alias replica_node_keys primary_node_keys
-        alias clients_for_scanning clients
         alias primary_clients clients
         alias replica_clients clients
 
-        def find_node_key_of_replica(primary_node_key)
+        def clients_for_scanning(random: Random) # rubocop:disable Lint/UnusedMethodArgument
+          @clients
+        end
+
+        def find_node_key_of_replica(primary_node_key, random: Random) # rubocop:disable Lint/UnusedMethodArgument
           primary_node_key
         end
+
+        def any_primary_node_key(random: Random)
+          @primary_node_keys.sample(random: random)
+        end
+
+        alias any_replica_node_key any_primary_node_key
 
         private
 

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -8,12 +8,13 @@ class RedisClient
 
         def initialize(replications, options, pool, **kwargs)
           @replications = replications
-          @clients = build_clients(@replications, options, pool, **kwargs)
           @primary_node_keys = @replications.keys.sort
+
+          @clients = build_clients(@primary_node_keys, options, pool, **kwargs)
         end
 
         alias replica_node_keys primary_node_keys
-        alias fixed_clients clients
+        alias clients_for_scanning clients
         alias primary_clients clients
         alias replica_clients clients
 
@@ -23,16 +24,13 @@ class RedisClient
 
         private
 
-        def build_clients(replications, options, pool, **kwargs)
+        def build_clients(primary_node_keys, options, pool, **kwargs)
           options.filter_map do |node_key, option|
-            next unless replications.key?(node_key)
+            next if !primary_node_keys.empty? && !primary_node_keys.include?(node_key)
 
-            config = ::RedisClient::Cluster::Node::Config.new(
-              scale_read: replica?(node_key),
-              **option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
-            )
+            option = option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+            config = ::RedisClient::Cluster::Node::Config.new(**option)
             client = pool.nil? ? config.new_client : config.new_pool(**pool)
-
             [node_key, client]
           end.to_h
         end

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -14,15 +14,16 @@ class RedisClient
         alias primary_clients clients
         alias replica_clients clients
 
-        def clients_for_scanning(random: Random) # rubocop:disable Lint/UnusedMethodArgument
+        def clients_for_scanning(seed: nil) # rubocop:disable Lint/UnusedMethodArgument
           @clients
         end
 
-        def find_node_key_of_replica(primary_node_key, random: Random) # rubocop:disable Lint/UnusedMethodArgument
+        def find_node_key_of_replica(primary_node_key, seed: nil) # rubocop:disable Lint/UnusedMethodArgument
           primary_node_key
         end
 
-        def any_primary_node_key(random: Random)
+        def any_primary_node_key(seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           @primary_node_keys.sample(random: random)
         end
 

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    class Node
+      class PrimaryOnly
+        attr_reader :clients, :primary_node_keys
+
+        def initialize(replications, options, pool, **kwargs)
+          @replications = replications
+          @clients = build_clients(@replications, options, pool, **kwargs)
+          @primary_node_keys = @replications.keys.sort
+        end
+
+        alias replica_node_keys primary_node_keys
+        alias fixed_clients clients
+        alias primary_clients clients
+        alias replica_clients clients
+
+        def find_node_key_of_replica(primary_node_key)
+          primary_node_key
+        end
+
+        private
+
+        def build_clients(replications, options, pool, **kwargs)
+          options.filter_map do |node_key, option|
+            next unless replications.key?(node_key)
+
+            config = ::RedisClient::Cluster::Node::Config.new(
+              scale_read: replica?(node_key),
+              **option.merge(kwargs.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+            )
+            client = pool.nil? ? config.new_client : config.new_pool(**pool)
+
+            [node_key, client]
+          end.to_h
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -29,7 +29,7 @@ class RedisClient
 
             config = ::RedisClient::Cluster::Node::Config.new(
               scale_read: replica?(node_key),
-              **option.merge(kwargs.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+              **option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
             )
             client = pool.nil? ? config.new_client : config.new_pool(**pool)
 

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -8,13 +8,22 @@ class RedisClient
       class RandomReplica
         include ::RedisClient::Cluster::Node::ReplicaMixin
 
+        attr_reader :clients_for_scanning
+
+        def initialize(replications, options, pool, **kwargs)
+          super
+
+          first_keys = @replications.values.map(&:first)
+          @clients_for_scanning = @clients.select { |k, _| first_keys.include?(k) }
+        end
+
         def replica_clients
           keys = @replications.values.map(&:sample)
           @clients.select { |k, _| keys.include?(k) }
         end
 
         def find_node_key_of_replica(primary_node_key)
-          @replications[primary_node_key].sample
+          @replications.fetch(primary_node_key, EMPTY_ARRAY).sample
         end
       end
     end

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    class Node
+      class RandomReplica
+        include ::RedisClient::Cluster::Node::ReplicaMixin
+
+        def replica_clients
+          keys = @replications.values.map(&:sample)
+          @clients.select { |k, _| keys.include?(k) }
+        end
+
+        def find_node_key_of_replica(primary_node_key)
+          @replications[primary_node_key].sample
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -13,8 +13,7 @@ class RedisClient
         def initialize(replications, options, pool, **kwargs)
           super
 
-          first_keys = @replications.values.map(&:first)
-          @clients_for_scanning = @clients.select { |k, _| first_keys.include?(k) }
+          @clients_for_scanning = select_first_clients(@replications, @clients)
         end
 
         def replica_clients

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -13,7 +13,8 @@ class RedisClient
           @clients.select { |k, _| keys.include?(k) }
         end
 
-        def clients_for_scanning(random: Random)
+        def clients_for_scanning(seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           keys = @replications.map do |primary_node_key, replica_node_keys|
             replica_node_keys.empty? ? primary_node_key : replica_node_keys.sample(random: random)
           end
@@ -21,11 +22,13 @@ class RedisClient
           clients.select { |k, _| keys.include?(k) }
         end
 
-        def find_node_key_of_replica(primary_node_key, random: Random)
+        def find_node_key_of_replica(primary_node_key, seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           @replications.fetch(primary_node_key, EMPTY_ARRAY).sample(random: random) || primary_node_key
         end
 
-        def any_replica_node_key(random: Random)
+        def any_replica_node_key(seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           @replica_node_keys.sample(random: random)
         end
       end

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'redis_client/cluster/node/replica_mixin'
+
 class RedisClient
   class Cluster
     class Node

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -27,6 +27,11 @@ class RedisClient
             [node_key, client]
           end.to_h
         end
+
+        def select_first_clients(replications, clients)
+          first_keys = replications.values.map(&:first)
+          clients.select { |k, _| first_keys.include?(k) }
+        end
       end
     end
   end

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -16,7 +16,8 @@ class RedisClient
           @primary_clients = @clients.select { |k, _| @primary_node_keys.include?(k) }
         end
 
-        def any_primary_node_key(random: Random)
+        def any_primary_node_key(seed: nil)
+          random = seed.nil? ? Random : Random.new(seed)
           @primary_node_keys.sample(random: random)
         end
 

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -4,28 +4,26 @@ class RedisClient
   class Cluster
     class Node
       module ReplicaMixin
-        attr_reader :clients, :primary_node_keys, :replica_node_keys, :fixed_clients, :primary_clients
+        attr_reader :clients, :primary_node_keys, :replica_node_keys, :primary_clients
+
+        EMPTY_ARRAY = [].freeze
 
         def initialize(replications, options, pool, **kwargs)
           @replications = replications
-          @clients = build_clients(options, pool, **kwargs)
           @primary_node_keys = @replications.keys.sort
           @replica_node_keys = @replications.values.flatten.sort
-          first_keys = @replications.values.map(&:first)
-          @fixed_clients = @clients.select { |k, _| first_keys.include?(k) }
+
+          @clients = build_clients(@replica_node_keys, options, pool, **kwargs)
           @primary_clients = @clients.select { |k, _| @primary_node_keys.include?(k) }
         end
 
         private
 
-        def build_clients(options, pool, **kwargs)
+        def build_clients(replica_node_keys, options, pool, **kwargs)
           options.filter_map do |node_key, option|
-            config = ::RedisClient::Cluster::Node::Config.new(
-              scale_read: replica?(node_key),
-              **option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
-            )
+            option = option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+            config = ::RedisClient::Cluster::Node::Config.new(scale_read: replica_node_keys.include?(node_key), **option)
             client = pool.nil? ? config.new_client : config.new_pool(**pool)
-
             [node_key, client]
           end.to_h
         end

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    class Node
+      module ReplicaMixin
+        attr_reader :clients, :primary_node_keys, :replica_node_keys, :fixed_clients, :primary_clients
+
+        def initialize(replications, options, pool, **kwargs)
+          @replications = replications
+          @clients = build_clients(options, pool, **kwargs)
+          @primary_node_keys = @replications.keys.sort
+          @replica_node_keys = @replications.values.flatten.sort
+          first_keys = @replications.values.map(&:first)
+          @fixed_clients = @clients.select { |k, _| first_keys.include?(k) }
+          @primary_clients = @clients.select { |k, _| @primary_node_keys.include?(k) }
+        end
+
+        private
+
+        def build_clients(options, pool, **kwargs)
+          options.filter_map do |node_key, option|
+            config = ::RedisClient::Cluster::Node::Config.new(
+              scale_read: replica?(node_key),
+              **option.merge(kwargs.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+            )
+            client = pool.nil? ? config.new_client : config.new_pool(**pool)
+
+            [node_key, client]
+          end.to_h
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -22,7 +22,7 @@ class RedisClient
           options.filter_map do |node_key, option|
             config = ::RedisClient::Cluster::Node::Config.new(
               scale_read: replica?(node_key),
-              **option.merge(kwargs.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
+              **option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
             )
             client = pool.nil? ? config.new_client : config.new_pool(**pool)
 

--- a/lib/redis_client/cluster/node/replica_mixin.rb
+++ b/lib/redis_client/cluster/node/replica_mixin.rb
@@ -4,7 +4,7 @@ class RedisClient
   class Cluster
     class Node
       module ReplicaMixin
-        attr_reader :clients, :primary_node_keys, :replica_node_keys, :primary_clients
+        attr_reader :clients, :primary_clients
 
         EMPTY_ARRAY = [].freeze
 
@@ -12,25 +12,23 @@ class RedisClient
           @replications = replications
           @primary_node_keys = @replications.keys.sort
           @replica_node_keys = @replications.values.flatten.sort
-
-          @clients = build_clients(@replica_node_keys, options, pool, **kwargs)
+          @clients = build_clients(@primary_node_keys, options, pool, **kwargs)
           @primary_clients = @clients.select { |k, _| @primary_node_keys.include?(k) }
+        end
+
+        def any_primary_node_key(random: Random)
+          @primary_node_keys.sample(random: random)
         end
 
         private
 
-        def build_clients(replica_node_keys, options, pool, **kwargs)
+        def build_clients(primary_node_keys, options, pool, **kwargs)
           options.filter_map do |node_key, option|
             option = option.merge(kwargs.reject { |k, _| ::RedisClient::Cluster::Node::IGNORE_GENERIC_CONFIG_KEYS.include?(k) })
-            config = ::RedisClient::Cluster::Node::Config.new(scale_read: replica_node_keys.include?(node_key), **option)
+            config = ::RedisClient::Cluster::Node::Config.new(scale_read: !primary_node_keys.include?(node_key), **option)
             client = pool.nil? ? config.new_client : config.new_pool(**pool)
             [node_key, client]
           end.to_h
-        end
-
-        def select_first_clients(replications, clients)
-          first_keys = replications.values.map(&:first)
-          clients.select { |k, _| first_keys.include?(k) }
         end
       end
     end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -14,46 +14,47 @@ class RedisClient
         @command_builder = command_builder
         @grouped = Hash.new([].freeze)
         @size = 0
+        @random = Random.new
       end
 
       def call(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
       def call_v(args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
       def call_once(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
       def call_once_v(args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
       def blocking_call(timeout, *args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end
 
       def blocking_call_v(timeout, args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, primary_only: true)
+        node_key = @router.find_node_key(command, random: @random)
         @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -14,47 +14,47 @@ class RedisClient
         @command_builder = command_builder
         @grouped = Hash.new([].freeze)
         @size = 0
-        @random = Random.new
+        @seed = Random.new_seed
       end
 
       def call(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
       def call_v(args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :call_v, command, block]]
         @size += 1
       end
 
       def call_once(*args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
       def call_once_v(args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :call_once_v, command, block]]
         @size += 1
       end
 
       def blocking_call(timeout, *args, **kwargs, &block)
         command = @command_builder.generate(args, kwargs)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end
 
       def blocking_call_v(timeout, args, &block)
         command = @command_builder.generate(args)
-        node_key = @router.find_node_key(command, random: @random)
+        node_key = @router.find_node_key(command, seed: @seed)
         @grouped[node_key] += [[@size, :blocking_call_v, timeout, command, block]]
         @size += 1
       end

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -20,10 +20,19 @@ class RedisClient
 
     InvalidClientConfigError = Class.new(::RedisClient::Error)
 
-    attr_reader :command_builder, :client_config
+    attr_reader :command_builder, :client_config, :replica_affinity
 
-    def initialize(nodes: DEFAULT_NODES, replica: false, client_implementation: Cluster, fixed_hostname: '', **client_config)
+    def initialize( # rubocop:disable Metrics/ParameterLists
+      nodes: DEFAULT_NODES,
+      replica: false,
+      replica_affinity: :random,
+      fixed_hostname: '',
+      client_implementation: Cluster,
+      **client_config
+    )
+
       @replica = true & replica
+      @replica_affinity = replica_affinity.to_s.to_sym
       @fixed_hostname = fixed_hostname.to_s
       @node_configs = build_node_configs(nodes.dup)
       client_config = client_config.reject { |k, _| IGNORE_GENERIC_CONFIG_KEYS.include?(k) }

--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -252,7 +252,7 @@ class ClusterController
       slot_range = slot_idx..slot_idx + s - 1
       c.call('CLUSTER', 'ADDSLOTS', *slot_range.to_a)
       slot_idx += s
-      print_debug("#{c.config.host}:#{c.config.port} ... #{slot_range.to_a}")
+      print_debug("#{c.config.host}:#{c.config.port} ... CLUSTER ADDSLOTS #{slot_range.to_a}")
     end
   end
 

--- a/test/redis_client/cluster/node/test_primary_only.rb
+++ b/test/redis_client/cluster/node/test_primary_only.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'testing_helper'
+
+class RedisClient
+  class Cluster
+    class Node
+      class TestPrimaryOnly < TestingWrapper
+        test_config = ::RedisClient::ClusterConfig.new(
+          nodes: TEST_NODE_URIS,
+          fixed_hostname: TEST_FIXED_HOSTNAME,
+          **TEST_GENERIC_OPTIONS
+        )
+        test_node_info = ::RedisClient::Cluster::Node.load_info(test_config.per_node_key)
+        if TEST_FIXED_HOSTNAME
+          test_node_info.each do |info|
+            _, port = ::RedisClient::Cluster::NodeKey.split(info[:node_key])
+            info[:node_key] = ::RedisClient::Cluster::NodeKey.build_from_host_port(TEST_FIXED_HOSTNAME, port)
+          end
+        end
+        node_addrs = test_node_info.map { |info| ::RedisClient::Cluster::NodeKey.hashify(info[:node_key]) }
+        test_config.update_node(node_addrs)
+        @options = test_config.per_node_key
+        @test_node = ::RedisClient::Cluster::Node.new(@options, node_info: test_node_info)
+        @cfg_attrs = %i[connect_timeout read_timeout write_timeout].freeze
+      end
+
+      def teardown
+        @test_node&.each(&:close)
+      end
+
+      def test_build_clients
+        subject = ::RedisClient::Cluster::Node::PrimaryOnly.new({}, {}, nil)
+
+        got = subject.send(:build_clients,
+                           @test_config.instance_variable_get(:@replications),
+                           @options,
+                           nil,
+                           **TEST_GENERIC_OPTIONS.merge(timeout: 10))
+
+        got.each_value { |client| assert_instance_of(::RedisClient, client) }
+        assert_equal(@test_node_info.count { |info| info[:role] == 'master' }, got.size)
+        got.each_value do |client|
+          @cfg_attrs.each { |attr| assert_equal(10, client.config.send(attr), "Case: #{attr}") }
+        end
+        got.each_value(&:close)
+      end
+
+      def test_build_clients_with_connection_pooling
+        subject = ::RedisClient::Cluster::Node::PrimaryOnly.new({}, {}, nil)
+
+        got = subject.send(:build_clients,
+                           @test_config.instance_variable_get(:@replications),
+                           @options,
+                           { timeout: 3, size: 2 },
+                           **TEST_GENERIC_OPTIONS.merge(timeout: 10))
+
+        got.each_value { |client| assert_instance_of(::RedisClient::Pooled, client) }
+        assert_equal(@test_node_info.count { |info| info[:role] == 'master' }, got.size)
+        got.each_value do |client|
+          @cfg_attrs.each { |attr| assert_equal(10, client.config.send(attr), "Case: #{attr}") }
+        end
+        got.each_value(&:close)
+      end
+    end
+  end
+end

--- a/test/redis_client/cluster/node/test_random_replica.rb
+++ b/test/redis_client/cluster/node/test_random_replica.rb
@@ -6,7 +6,7 @@ require 'testing_helper'
 class RedisClient
   class Cluster
     class Node
-      class TestPrimaryOnly < TestingWrapper
+      class TestRandomReplica < TestingWrapper
         def setup
           test_config = ::RedisClient::ClusterConfig.new(
             nodes: TEST_NODE_URIS,
@@ -26,7 +26,7 @@ class RedisClient
           test_node = ::RedisClient::Cluster::Node.new(@options, node_info: test_node_info)
           @replications = test_node.instance_variable_get(:@replications)
           test_node&.each(&:close)
-          @test_topology = ::RedisClient::Cluster::Node::PrimaryOnly.new(
+          @test_topology = ::RedisClient::Cluster::Node::RandomReplica.new(
             @replications,
             @options,
             nil,
@@ -40,14 +40,12 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_topology.clients
-          got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
-            assert_equal('master', client.call('ROLE').first)
-          end
+          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_clients_with_pooled_redis_client
-          test_topology = ::RedisClient::Cluster::Node::PrimaryOnly.new(
+          test_topology = ::RedisClient::Cluster::Node::RandomReplica.new(
             @replications,
             @options,
             { timeout: 3, size: 2 },
@@ -55,10 +53,8 @@ class RedisClient
           )
 
           got = test_topology.clients
-          got.each_value do |client|
-            assert_instance_of(::RedisClient::Pooled, client)
-            assert_equal('master', client.call('ROLE').first)
-          end
+          got.each_value { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         ensure
           test_topology&.clients&.each_value(&:close)
         end
@@ -75,22 +71,25 @@ class RedisClient
           got = @test_topology.replica_clients
           got.each_value do |client|
             assert_instance_of(::RedisClient, client)
-            assert_equal('master', client.call('ROLE').first)
+            assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_topology.clients_for_scanning
-          got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
-            assert_equal('master', client.call('ROLE').first)
-          end
+          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          assert_equal(TEST_SHARD_SIZE, got.size)
         end
 
         def test_find_node_key_of_replica
           want = 'dummy_key'
           got = @test_topology.find_node_key_of_replica('dummy_key')
           assert_equal(want, got)
+
+          primary_key = @replications.keys.first
+          replica_keys = @replications.fetch(primary_key)
+          got = @test_topology.find_node_key_of_replica(primary_key)
+          assert_includes(replica_keys, got)
         end
 
         def test_any_primary_node_key
@@ -100,7 +99,7 @@ class RedisClient
 
         def test_any_replica_node_key
           got = @test_topology.any_replica_node_key
-          assert_includes(@replications.keys, got)
+          assert_includes(@replications.values.flatten, got)
         end
       end
     end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -314,7 +314,7 @@ class RedisClient
           { with_replica: false, replica_affinity: :foo, want: ::RedisClient::Cluster::Node::PrimaryOnly },
           { with_replica: true, replica_affinity: :foo, want: ::RedisClient::Cluster::Node::PrimaryOnly },
           { with_replica: true, replica_affinity: :random, want: ::RedisClient::Cluster::Node::RandomReplica },
-          { with_replica: true, replica_affinity: :nearest, want: ::RedisClient::Cluster::Node::NearestReplica }
+          { with_replica: true, replica_affinity: :latency, want: ::RedisClient::Cluster::Node::LatencyReplica }
         ].each_with_index do |c, i|
           got = @test_node.send(:make_topology_class, c[:with_replica], c[:replica_affinity])
           assert_equal(c[:want], got, "Case: #{i}")

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -209,22 +209,6 @@ class RedisClient
         end
       end
 
-      def test_primary_node_keys
-        want = @test_node_info.filter_map { |info| info[:role] == 'master' ? info[:node_key] : nil }.sort
-        got = @test_node.primary_node_keys
-        assert_equal(want, got)
-      end
-
-      def test_replica_node_keys
-        want = @test_node_info.filter_map { |info| info[:role] == 'master' ? info[:node_key] : nil }.sort
-        got = @test_node.replica_node_keys
-        assert_equal(want, got)
-
-        want = @test_node_info.filter_map { |info| info[:role] == 'slave' ? info[:node_key] : nil }.sort
-        got = @test_node_with_scale_read.replica_node_keys
-        assert_equal(want, got)
-      end
-
       def test_find_by
         @test_node_info.each do |info|
           msg = "Case: primary only: #{info[:node_key]}"

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -393,7 +393,8 @@ class RedisClient
           { block: ->(_, client) { client.call('UNKNOWN') }, errors: ::RedisClient::CommandError }
         ].each_with_index do |c, idx|
           msg = "Case: #{idx}"
-          results, errors = @test_node.send(:try_map, &c[:block])
+          clients = @test_node.instance_variable_get(:@topology).clients
+          results, errors = @test_node.send(:try_map, clients, &c[:block])
           if c.key?(:errors)
             errors.each_value { |e| assert_instance_of(c[:errors], e, msg) }
           else

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -237,8 +237,12 @@ class RedisClient
 
       def test_call_primaries
         want = (1..(@test_node_info.count { |info| info[:role] == 'master' })).map { |_| 'PONG' }
+
         got = @test_node.call_primaries(:call_v, ['PING'], [])
         assert_equal(want, got)
+
+        got = @test_node_with_scale_read.call_primaries(:call_v, ['PING'], [])
+        assert_equal(want, got, 'Case: scale read')
       end
 
       def test_call_replicas
@@ -252,11 +256,11 @@ class RedisClient
       end
 
       def test_send_ping
-        want = (1..(@test_node_info.count)).map { |_| 'PONG' }
-
+        want = (1..(@test_node_info.count { |info| info[:role] == 'master' })).map { |_| 'PONG' }
         got = @test_node.send_ping(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: primary only')
 
+        want = (1..(@test_node_info.count)).map { |_| 'PONG' }
         got = @test_node_with_scale_read.send_ping(:call_v, ['PING'], [])
         assert_equal(want, got, 'Case: scale read')
       end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -116,15 +116,22 @@ class RedisClient
       def test_pipelined
         assert_empty([], @client.pipelined { |_| 1 + 1 })
 
-        want = (0..9).map { 'OK' } + (1..3).to_a + %w[PONG] + (0..9).map(&:to_s) + [%w[list 2]]
+        want = (0..9).map { 'OK' } + (1..3).to_a + %w[PONG]
         got = @client.pipelined do |pipeline|
           10.times { |i| pipeline.call('SET', "string#{i}", i) }
           3.times { |i| pipeline.call('RPUSH', 'list', i) }
           pipeline.call_once('PING')
+        end
+        assert_equal(want, got)
+
+        wait_for_replication
+
+        want = %w[PONG] + (0..9).map(&:to_s) + [%w[list 2]]
+        got = @client.pipelined do |pipeline|
+          pipeline.call_once('PING')
           10.times { |i| pipeline.call('GET', "string#{i}") }
           pipeline.blocking_call(0.2, 'BRPOP', 'list', '0.1')
         end
-
         assert_equal(want, got)
       end
 

--- a/test/redis_client/test_cluster_config.rb
+++ b/test/redis_client/test_cluster_config.rb
@@ -70,6 +70,22 @@ class RedisClient
       refute_predicate(::RedisClient::ClusterConfig.new, :use_replica?)
     end
 
+    def test_replica_affinity
+      [
+        { value: :random, want: :random },
+        { value: 'random', want: :random },
+        { value: :nearest, want: :nearest },
+        { value: 'nearest', want: :nearest },
+        { value: :unknown, want: :unknown },
+        { value: 'unknown', want: :unknown },
+        { value: 0, want: :'0' },
+        { value: nil, want: :'' }
+      ].each do |c|
+        cfg = ::RedisClient::ClusterConfig.new(replica_affinity: c[:value])
+        assert_equal(c[:want], cfg.replica_affinity)
+      end
+    end
+
     def test_update_node
       config = ::RedisClient::ClusterConfig.new(nodes: %w[redis://127.0.0.1:6379])
       assert_equal([{ host: '127.0.0.1', port: 6379 }], config.instance_variable_get(:@node_configs))

--- a/test/redis_client/test_cluster_config.rb
+++ b/test/redis_client/test_cluster_config.rb
@@ -74,8 +74,8 @@ class RedisClient
       [
         { value: :random, want: :random },
         { value: 'random', want: :random },
-        { value: :nearest, want: :nearest },
-        { value: 'nearest', want: :nearest },
+        { value: :latency, want: :latency },
+        { value: 'latency', want: :latency },
         { value: :unknown, want: :unknown },
         { value: 'unknown', want: :unknown },
         { value: 0, want: :'0' },

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -36,7 +36,11 @@ class TestAgainstClusterScale < TestingWrapper
     NUMBER_OF_KEYS.times { |i| assert_equal(i.to_s, @client.call('GET', "key#{i}"), "Case: key#{i}") }
 
     want = (TEST_NODE_URIS + build_additional_node_urls).size
-    got = @client.instance_variable_get(:@router).instance_variable_get(:@node).instance_variable_get(:@clients).size
+    got = @client.instance_variable_get(:@router)
+                 .instance_variable_get(:@node)
+                 .instance_variable_get(:@topology)
+                 .instance_variable_get(:@clients)
+                 .size
     assert_equal(want, got, 'Case: number of nodes')
   end
 
@@ -53,7 +57,11 @@ class TestAgainstClusterScale < TestingWrapper
     end
 
     want = TEST_NODE_URIS.size
-    got = @client.instance_variable_get(:@router).instance_variable_get(:@node).instance_variable_get(:@clients).size
+    got = @client.instance_variable_get(:@router)
+                 .instance_variable_get(:@node)
+                 .instance_variable_get(:@topology)
+                 .instance_variable_get(:@clients)
+                 .size
     assert_equal(want, got, 'Case: number of nodes')
   end
 


### PR DESCRIPTION
closes #96

```ruby
RedisClient.cluster(replica: true, replica_affinity: :latency).new_client
```

The client becomes able to prioritize replicas by latency.

- [x] fix test cases and enbugs
- [x] add unit test cases
- [x] refactoring
- [x] consider sticky node for `SCAN` and pipelining
- [x] add a docker compose file for NAT