### PR TITLE
perf: reduce memory allocations for pipelining

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -338,3 +338,32 @@ jobs:
           done
       - name: Stop containers
         run: docker compose -f $DOCKER_COMPOSE_FILE down
+  memory-profile:
+    name: Memory Profile
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      REDIS_VERSION: '7.0.1'
+      DOCKER_COMPOSE_FILE: 'compose.yaml'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Pull Docker images
+        run: docker pull redis:$REDIS_VERSION
+      - name: Run containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE up -d
+      - name: Wait for Redis cluster to be ready
+        run: bundle exec rake wait
+      - name: Print containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE ps
+      - name: Run minitest
+        run: bundle exec rake prof
+      - name: Stop containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE down

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -363,7 +363,7 @@ jobs:
         run: bundle exec rake wait
       - name: Print containers
         run: docker compose -f $DOCKER_COMPOSE_FILE ps
-      - name: Run minitest
+      - name: Run memory profiler
         run: bundle exec rake prof
       - name: Stop containers
         run: docker compose -f $DOCKER_COMPOSE_FILE down

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec name: 'redis-cluster-client'
 
 gem 'hiredis-client', '~> 0.6'
+gem 'memory_profiler'
 gem 'minitest'
 gem 'rake'
 gem 'rubocop'

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,14 @@ Rake::TestTask.new(:bench) do |t|
   t.test_files = ARGV.size > 1 ? ARGV[1..] : Dir['test/**/bench_*.rb']
 end
 
+Rake::TestTask.new(:prof) do |t|
+  t.libs << :lib
+  t.libs << :test
+  t.options = '-v'
+  t.warning = false
+  t.test_files = ARGV.size > 1 ? ARGV[1..] : Dir['test/**/prof_*.rb']
+end
+
 desc 'Wait for cluster to be ready'
 task :wait do
   $LOAD_PATH.unshift(File.expand_path('test', __dir__))

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -78,7 +78,7 @@ class RedisClient
     end
 
     def pipelined
-      seed = @config.replica_affinity == :random ? nil : Random.new_seed
+      seed = @config.use_replica? && @config.replica_affinity == :random ? nil : Random.new_seed
       pipeline = ::RedisClient::Cluster::Pipeline.new(@router, @command_builder, seed: seed)
       yield pipeline
       return [] if pipeline.empty? == 0

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -78,7 +78,8 @@ class RedisClient
     end
 
     def pipelined
-      pipeline = ::RedisClient::Cluster::Pipeline.new(@router, @command_builder)
+      seed = @config.replica_affinity == :random ? nil : Random.new_seed
+      pipeline = ::RedisClient::Cluster::Pipeline.new(@router, @command_builder, seed: seed)
       yield pipeline
       return [] if pipeline.empty? == 0
 

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -72,14 +72,14 @@ class RedisClient
       end
 
       def dig_details(command, key)
-        name = command&.flatten&.first.to_s.downcase
+        name = command&.flatten&.first.to_s.downcase # OPTIMIZE: prevent allocation for string
         return if name.empty? || !@details.key?(name)
 
         @details.fetch(name).fetch(key)
       end
 
       def determine_first_key_position(command) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
-        case command&.flatten&.first.to_s.downcase
+        case command&.flatten&.first.to_s.downcase # OPTIMIZE: prevent allocation for string
         when 'eval', 'evalsha', 'zinterstore', 'zunionstore' then 3
         when 'object' then 2
         when 'memory'

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'memory_profiler'
+require 'redis_cluster_client'
+require 'testing_constants'
+
+module ProfMem
+  module_function
+
+  ATTEMPT_COUNT = 1000
+
+  def run
+    %w[primary_only scale_read_random scale_read_latency pooled].each do |cli_type|
+      p cli_type
+
+      profile do
+        send("new_#{cli_type}_client".to_sym).pipelined do |pi|
+          ATTEMPT_COUNT.times { |i| pi.call('SET', "key#{i}", i) }
+          ATTEMPT_COUNT.times { |i| pi.call('GET', "key#{i}") }
+        end
+      end
+    end
+  end
+
+  def profile(&block)
+    # https://github.com/SamSaffron/memory_profiler
+    report = ::MemoryProfiler.report(top: 10, &block)
+    report.pretty_print(color_output: true, normalize_paths: true)
+  end
+
+  def new_primary_only_client
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      **TEST_GENERIC_OPTIONS
+    ).new_client
+  end
+
+  def new_scale_read_random_client
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      replica: true,
+      replica_affinity: :random,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      **TEST_GENERIC_OPTIONS
+    ).new_client
+  end
+
+  def new_scale_read_latency_client
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      replica: true,
+      replica_affinity: :latency,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      **TEST_GENERIC_OPTIONS
+    ).new_client
+  end
+
+  def new_pooled_client
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      **TEST_GENERIC_OPTIONS
+    ).new_pool(
+      timeout: TEST_TIMEOUT_SEC,
+      size: 2
+    )
+  end
+end
+
+ProfMem.run

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -11,7 +11,10 @@ module ProfMem
 
   def run
     %w[primary_only scale_read_random scale_read_latency pooled].each do |cli_type|
-      p cli_type
+      print "################################################################################\n"
+      print "# #{cli_type}\n"
+      print "################################################################################\n"
+      print "\n"
 
       profile do
         send("new_#{cli_type}_client".to_sym).pipelined do |pi|


### PR DESCRIPTION
# Before

```
Total allocated: 9068094 bytes (68763 objects)
```

```
allocated memory by location
-----------------------------------
   5645840  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:23
    546680  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    320000  redis-cluster-client/lib/redis_client/cluster/command.rb:75
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    160000  redis-cluster-client/lib/redis_client/cluster/command.rb:82
    160000  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:75
```

```
allocated memory by class
-----------------------------------
   6869008  Array
   1746294  String
    417272  Hash
     19080  Addrinfo
      3744  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```

# After

```
Total allocated: 3598328 bytes (64767 objects)
```

```
allocated memory by location
-----------------------------------
    546680  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    320000  redis-cluster-client/lib/redis_client/cluster/command.rb:75
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    160000  redis-cluster-client/lib/redis_client/cluster/command.rb:82
    160000  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:69
    159600  /home/kasuga/vcs/redis-cluster-client/test/prof_mem.rb:21
```

```
allocated memory by class
-----------------------------------
   1754568  String
   1390840  Array
    417440  Hash
     19080  Addrinfo
      3744  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```