### PR TITLE
perf: reduce memory allocations for string and array

### DIFF
--- a/docs/class_diagrams_redis_client.md
+++ b/docs/class_diagrams_redis_client.md
@@ -19,8 +19,11 @@ classDiagram
     +write_timeout=()
     +pubsub()
     +call()
+    +call_v()
     +call_once()
+    +call_once_v()
     +blocking_call()
+    +blocking_call_v()
     +scan()
     +sscan()
     +hscan()
@@ -46,6 +49,7 @@ classDiagram
   class RedisClient_PubSub {
     +initialize()
     +call()
+    +call_v()
     +close()
     +next_event()
   }
@@ -53,12 +57,15 @@ classDiagram
   class RedisClient_Multi {
     +initialize()
     +call()
+    +call_v()
     +call_once()
+    +call_once_v()
   }
 
   class RedisClient_Pipeline {
     +initialize()
     +blocking_call()
+    +blocking_call_v()
   }
 
   class RedisClient_RubyConnection_BufferedIO {

--- a/docs/class_diagrams_redis_cluster_client.md
+++ b/docs/class_diagrams_redis_cluster_client.md
@@ -99,14 +99,18 @@ classDiagram
 
   class RedisClient_Cluster_Pipeline {
     +call()
+    +call_v()
     +call_once()
+    +call_once_v()
     +blocking_call()
+    +blocking_call_v()
     +empty?()
     +execute()
   }
 
   class RedisClient_Cluster_PubSub {
     +call()
+    +call_v()
     +close()
     +next_event()
   }

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -6,6 +6,8 @@ require 'redis_client/cluster/errors'
 class RedisClient
   class Cluster
     class Command
+      EMPTY_STRING = ''
+
       class << self
         def load(nodes) # rubocop:disable Metrics/MethodLength
           errors = []
@@ -41,7 +43,7 @@ class RedisClient
 
       def extract_first_key(command)
         i = determine_first_key_position(command)
-        return '' if i == 0
+        return EMPTY_STRING if i == 0
 
         key = (command[i].is_a?(Array) ? command[i].flatten.first : command[i]).to_s
         hash_tag = extract_hash_tag(key)
@@ -105,19 +107,19 @@ class RedisClient
         s = key.index('{')
         e = key.index('}', s.to_i + 1)
 
-        return '' if s.nil? || e.nil?
+        return EMPTY_STRING if s.nil? || e.nil?
 
         key[s + 1..e - 1]
       end
 
       def normalize_cmd_name(command)
-        return unless command.is_a?(Array)
+        return EMPTY_STRING unless command.is_a?(Array)
 
         name = case e = command.first
                when String then e
                when Array then e.first
                end
-        return if name.nil?
+        return EMPTY_STRING if name.nil? || name.empty?
 
         @normalized_cmd_name_cache[name] = name.downcase unless @normalized_cmd_name_cache.key?(name)
         @normalized_cmd_name_cache[name]

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -66,8 +66,11 @@ class RedisClient
             Thread.new(@router, k, v) do |router, node_key, rows|
               Thread.pass
               replies = router.find_node(node_key).pipelined do |pipeline|
-                rows.each do |(_size, *row, block)|
-                  pipeline.send(*row, &block)
+                rows.each do |row|
+                  case row.size
+                  when 4 then pipeline.send(row[1], row[2], &row[3])
+                  when 5 then pipeline.send(row[1], row[2], row[3], &row[4])
+                  end
                 end
               end
 

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -18,8 +18,8 @@ module ProfMem
 
       profile do
         send("new_#{cli_type}_client".to_sym).pipelined do |pi|
-          ATTEMPT_COUNT.times { |i| pi.call('SET', "key#{i}", i) }
-          ATTEMPT_COUNT.times { |i| pi.call('GET', "key#{i}") }
+          ATTEMPT_COUNT.times { |i| pi.call('SET', i, i) }
+          ATTEMPT_COUNT.times { |i| pi.call('GET', i) }
         end
       end
     end


### PR DESCRIPTION
# Before

```
Total allocated: 3594279 bytes (64765 objects)
```

```
allocated memory by location
-----------------------------------
    546600  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    320000  redis-cluster-client/lib/redis_client/cluster/command.rb:75
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    160000  redis-cluster-client/lib/redis_client/cluster/command.rb:82
    160000  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:69
    159600  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb:21
```

```
allocated memory by class
-----------------------------------
   1750495  String
   1390824  Array
    417440  Hash
     19080  Addrinfo
      3744  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```

# After

```
Total allocated: 2930089 bytes (48771 objects)
```

```
allocated memory by location
-----------------------------------
    546680  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    159600  /home/kasuga/vcs/redis-cluster-client/test/prof_mem.rb:21
    159600  /home/kasuga/vcs/redis-cluster-client/test/prof_mem.rb:22
    144000  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:23
    132400  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:161
```

```
allocated memory by class
-----------------------------------
   1485929  String
    990840  Array
    417800  Hash
     19080  Addrinfo
      3744  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```