### PR TITLE
perf: reduce memory allocations

### DIFF
--- a/lib/redis_client/cluster/normalized_cmd_name.rb
+++ b/lib/redis_client/cluster/normalized_cmd_name.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+class RedisClient
+  class Cluster
+    class NormalizedCmdName
+      include Singleton
+
+      EMPTY_STRING = ''
+
+      def initialize
+        @cache = {}
+        @mutex = Mutex.new
+      end
+
+      def get_by_command(command)
+        get(command, index: 0)
+      end
+
+      def get_by_subcommand(command)
+        get(command, index: 1)
+      end
+
+      def get_by_name(name)
+        normalize(name)
+      end
+
+      def clear
+        @mutex.synchronize { @cache = {} }
+      end
+
+      private
+
+      def get(command, index:)
+        return EMPTY_STRING unless command.is_a?(Array)
+
+        name = extract_name(command, index: index)
+        return EMPTY_STRING if name.nil? || name.empty?
+
+        normalize(name)
+      end
+
+      def extract_name(command, index:)
+        case e = command[index]
+        when String then e
+        when Array then e[index]
+        end
+      end
+
+      def normalize(name)
+        return @cache[name] if @cache.key?(name)
+        return name.to_s.downcase if @mutex.locked?
+
+        @mutex.synchronize { @cache[name] = name.to_s.downcase }
+        @cache[name]
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/normalized_cmd_name.rb
+++ b/lib/redis_client/cluster/normalized_cmd_name.rb
@@ -23,18 +23,16 @@ class RedisClient
       end
 
       def get_by_name(name)
-        normalize(name)
+        get(name, index: 0)
       end
 
       def clear
-        @mutex.synchronize { @cache = {} }
+        @mutex.synchronize { @cache.clear }
       end
 
       private
 
       def get(command, index:)
-        return EMPTY_STRING unless command.is_a?(Array)
-
         name = extract_name(command, index: index)
         return EMPTY_STRING if name.nil? || name.empty?
 
@@ -42,8 +40,17 @@ class RedisClient
       end
 
       def extract_name(command, index:)
+        case command
+        when String, Symbol then index.zero? ? command : nil
+        when Array then extract_name_from_array(command, index: index)
+        end
+      end
+
+      def extract_name_from_array(command, index:)
+        return if command.size - 1 < index
+
         case e = command[index]
-        when String then e
+        when String, Symbol then e
         when Array then e[index]
         end
       end

--- a/test/bench_command.rb
+++ b/test/bench_command.rb
@@ -10,12 +10,11 @@ class BenchCommand
     private
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config)
+      ).new_client
     end
   end
 
@@ -25,14 +24,13 @@ class BenchCommand
     private
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         replica: true,
         replica_affinity: :random,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config)
+      ).new_client
     end
   end
 
@@ -42,14 +40,13 @@ class BenchCommand
     private
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         replica: true,
         replica_affinity: :latency,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config)
+      ).new_client
     end
   end
 
@@ -59,12 +56,11 @@ class BenchCommand
     private
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config, pool: { timeout: TEST_TIMEOUT_SEC, size: 2 })
+      ).new_pool(timeout: TEST_TIMEOUT_SEC, size: 2)
     end
   end
 

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -11,6 +11,7 @@ module ProfMem
 
   def run
     %w[primary_only scale_read_random scale_read_latency pooled].each do |cli_type|
+      prepare
       print_letter(cli_type, 'w/ pipelining')
       profile do
         send("new_#{cli_type}_client".to_sym).pipelined do |pi|
@@ -19,6 +20,7 @@ module ProfMem
         end
       end
 
+      prepare
       print_letter(cli_type, 'w/o pipelining')
       profile do
         cli = send("new_#{cli_type}_client".to_sym)
@@ -26,6 +28,10 @@ module ProfMem
         ATTEMPT_COUNT.times { |i| cli.call('GET', i) }
       end
     end
+  end
+
+  def prepare
+    ::RedisClient::Cluster::NormalizedCmdName.instance.clear
   end
 
   def print_letter(title, sub_titile)

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -11,18 +11,28 @@ module ProfMem
 
   def run
     %w[primary_only scale_read_random scale_read_latency pooled].each do |cli_type|
-      print "################################################################################\n"
-      print "# #{cli_type}\n"
-      print "################################################################################\n"
-      print "\n"
-
+      print_letter(cli_type, 'w/ pipelining')
       profile do
         send("new_#{cli_type}_client".to_sym).pipelined do |pi|
           ATTEMPT_COUNT.times { |i| pi.call('SET', i, i) }
           ATTEMPT_COUNT.times { |i| pi.call('GET', i) }
         end
       end
+
+      print_letter(cli_type, 'w/o pipelining')
+      profile do
+        cli = send("new_#{cli_type}_client".to_sym)
+        ATTEMPT_COUNT.times { |i| cli.call('SET', i, i) }
+        ATTEMPT_COUNT.times { |i| cli.call('GET', i) }
+      end
     end
+  end
+
+  def print_letter(title, sub_titile)
+    print "################################################################################\n"
+    print "# #{title}: #{sub_titile}\n"
+    print "################################################################################\n"
+    print "\n"
   end
 
   def profile(&block)

--- a/test/redis_client/cluster/test_normalized_cmd_name.rb
+++ b/test/redis_client/cluster/test_normalized_cmd_name.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'testing_helper'
+
+class RedisClient
+  class Cluster
+    class TestNormalizedCmdName < TestingWrapper
+      def setup
+        @subject = ::RedisClient::Cluster::NormalizedCmdName.instance
+        @subject.clear
+      end
+
+      def teardown
+        @subject.clear
+      end
+
+      def test_get_by_command
+        assert_equal('set', @subject.get_by_command(%w[SET foo bar]))
+      end
+
+      def test_get_by_subcommand
+        assert_equal('cat', @subject.get_by_subcommand(%w[ACL CAT dangerous]))
+      end
+
+      def test_get_by_name
+        assert_equal('ping', @subject.get_by_name('PING'))
+      end
+    end
+  end
+end

--- a/test/redis_client/cluster/test_normalized_cmd_name.rb
+++ b/test/redis_client/cluster/test_normalized_cmd_name.rb
@@ -15,15 +15,70 @@ class RedisClient
       end
 
       def test_get_by_command
-        assert_equal('set', @subject.get_by_command(%w[SET foo bar]))
+        [
+          { want: 'set', command: %w[SET foo bar] },
+          { want: 'set', command: %i[SET foo bar] },
+          { want: 'set', command: 'SET' },
+          { want: 'set', command: 'Set' },
+          { want: 'set', command: :set },
+          { want: '', command: [] },
+          { want: '', command: {} },
+          { want: '', command: '' },
+          { want: '', command: nil }
+        ].each do |c|
+          got = @subject.get_by_command(c[:command])
+          assert_equal(c[:want], got, "Case: #{c[:command]}")
+        end
       end
 
       def test_get_by_subcommand
-        assert_equal('cat', @subject.get_by_subcommand(%w[ACL CAT dangerous]))
+        [
+          { want: 'cat', command: %w[ACL CAT dangerous] },
+          { want: 'cat', command: %w[acl cat dangerous] },
+          { want: 'cat', command: %i[ACL CAT dangerous] },
+          { want: '', command: 'ACL CAT dangerous' },
+          { want: '', command: :acl },
+          { want: '', command: [] },
+          { want: '', command: {} },
+          { want: '', command: '' },
+          { want: '', command: nil }
+        ].each do |c|
+          got = @subject.get_by_subcommand(c[:command])
+          assert_equal(c[:want], got, "Case: #{c[:command]}")
+        end
       end
 
       def test_get_by_name
-        assert_equal('ping', @subject.get_by_name('PING'))
+        [
+          { want: 'ping', name: 'PING' },
+          { want: 'ping', name: :ping },
+          { want: '', name: [] },
+          { want: '', name: {} },
+          { want: '', name: '' },
+          { want: '', name: nil }
+        ].each do |c|
+          got = @subject.get_by_name(c[:name])
+          assert_equal(c[:want], got, "Case: #{c[:name]}")
+        end
+      end
+
+      def test_thread_safety
+        results = Array.new(10, true)
+        threads = results.each_with_index.map do |_, i|
+          Thread.new do
+            Thread.pass
+            if i.even?
+              results[i] = @subject.get_by_command(%w[SET foo bar]) == 'set'
+            else
+              @subject.clear
+            end
+          rescue StandardError
+            results[i] = false
+          end
+        end
+
+        threads.each(&:join)
+        refute_includes(results, false)
       end
     end
   end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -241,13 +241,29 @@ class RedisClient
       end
     end
 
-    class ScaleRead < TestingWrapper
+    class ScaleReadRandom < TestingWrapper
       include Mixin
 
       def new_test_client
         config = ::RedisClient::ClusterConfig.new(
           nodes: TEST_NODE_URIS,
           replica: true,
+          replica_affinity: :random,
+          fixed_hostname: TEST_FIXED_HOSTNAME,
+          **TEST_GENERIC_OPTIONS
+        )
+        ::RedisClient::Cluster.new(config)
+      end
+    end
+
+    class ScaleReadLatency < TestingWrapper
+      include Mixin
+
+      def new_test_client
+        config = ::RedisClient::ClusterConfig.new(
+          nodes: TEST_NODE_URIS,
+          replica: true,
+          replica_affinity: :latency,
           fixed_hostname: TEST_FIXED_HOSTNAME,
           **TEST_GENERIC_OPTIONS
         )

--- a/test/test_against_cluster_broken.rb
+++ b/test/test_against_cluster_broken.rb
@@ -6,13 +6,12 @@ class TestAgainstClusterBroken < TestingWrapper
   WAIT_SEC = 3
 
   def setup
-    config = ::RedisClient::ClusterConfig.new(
+    @client = ::RedisClient.cluster(
       nodes: TEST_NODE_URIS,
       replica: true,
       fixed_hostname: TEST_FIXED_HOSTNAME,
       **TEST_GENERIC_OPTIONS
-    )
-    @client = ::RedisClient::Cluster.new(config)
+    ).new_client
     @controller = ClusterController.new(
       TEST_NODE_URIS,
       replica_size: TEST_REPLICA_SIZE,

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -10,13 +10,12 @@ class TestAgainstClusterScale < TestingWrapper
   end
 
   def setup
-    config = ::RedisClient::ClusterConfig.new(
+    @client = ::RedisClient.cluster(
       nodes: TEST_NODE_URIS,
       replica: true,
       fixed_hostname: TEST_FIXED_HOSTNAME,
       **TEST_GENERIC_OPTIONS
-    )
-    @client = ::RedisClient::Cluster.new(config)
+    ).new_client
   end
 
   def teardown

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -93,27 +93,40 @@ class TestAgainstClusterState < TestingWrapper
     include Mixin
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config)
+      ).new_client
     end
   end
 
-  # TODO: https://github.com/redis-rb/redis-cluster-client/issues/42
-  # class ScaleRead < TestingWrapper
+  # # TODO: https://github.com/redis-rb/redis-cluster-client/issues/42
+  # class ScaleReadRandom < TestingWrapper
   #   include Mixin
   #
   #   def new_test_client
-  #     config = ::RedisClient::ClusterConfig.new(
+  #     ::RedisClient.cluster(
   #       nodes: TEST_NODE_URIS,
   #       replica: true,
+  #       replica_affinity: :random,
   #       fixed_hostname: TEST_FIXED_HOSTNAME,
   #       **TEST_GENERIC_OPTIONS
-  #     )
-  #     ::RedisClient::Cluster.new(config)
+  #     ).new_client
+  #   end
+  # end
+  #
+  # class ScaleReadLatency < TestingWrapper
+  #   include Mixin
+  #
+  #   def new_test_client
+  #     ::RedisClient.cluster(
+  #       nodes: TEST_NODE_URIS,
+  #       replica: true,
+  #       replica_affinity: :latency,
+  #       fixed_hostname: TEST_FIXED_HOSTNAME,
+  #       **TEST_GENERIC_OPTIONS
+  #     ).new_client
   #   end
   # end
 
@@ -121,12 +134,11 @@ class TestAgainstClusterState < TestingWrapper
     include Mixin
 
     def new_test_client
-      config = ::RedisClient::ClusterConfig.new(
+      ::RedisClient.cluster(
         nodes: TEST_NODE_URIS,
         fixed_hostname: TEST_FIXED_HOSTNAME,
         **TEST_GENERIC_OPTIONS
-      )
-      ::RedisClient::Cluster.new(config, pool: { timeout: TEST_TIMEOUT_SEC, size: 2 })
+      ).new_pool(timeout: TEST_TIMEOUT_SEC, size: 2)
     end
   end
 end


### PR DESCRIPTION
# Before

```
################################################################################
# primary_only: w/o pipelining
################################################################################
Total allocated: 3923319 bytes (60737 objects)
```

```
allocated memory by location
-----------------------------------
    677376  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:54
    546680  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    338688  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:55
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    240000  redis-cluster-client/lib/redis_client/cluster/router.rb:68
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    132400  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:161
```

```
allocated memory by class
-----------------------------------
   1716111  String
   1086880  Hash
   1086776  Array
     19080  Addrinfo
      2832  MatchData
      2496  Thread
      2160  Socket
      1728  RedisClient::Cluster::Node::Config
       936  RedisClient
       864  RedisClient::RubyConnection::BufferedIO
```

# After

```
################################################################################
# primary_only: w/o pipelining
################################################################################

Total allocated: 3607288 bytes (52737 objects)
Total retained:  17480 bytes (437 objects)
```

```
allocated memory by location
-----------------------------------
    677376  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:54
    546680  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    338688  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:55
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:202
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    132400  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:161
    120000  redis-client-0.8.1/lib/redis_client/command_builder.rb:35
```

```
allocated memory by class
-----------------------------------
   1640248  String
   1086712  Hash
    846776  Array
     19080  Addrinfo
      2832  MatchData
      2496  Thread
      2160  Socket
      1728  RedisClient::Cluster::Node::Config
       936  RedisClient
       864  RedisClient::RubyConnection::BufferedIO
```