### PR TITLE
perf: reduce memory allocations for pipelining

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,18 @@ Metrics/AbcSize:
     - 'test/**/*'
 
 Metrics/ClassLength:
-  Max: 400
+  Max: 500
+
+Metrics/ModuleLength:
+  Max: 500
 
 Metrics/MethodLength:
   Max: 50
+  Exclude:
+    - 'test/**/*'
+
+Metrics/BlockLength:
+  Max: 25
   Exclude:
     - 'test/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
   Max: 400
 
 Metrics/MethodLength:
+  Max: 50
   Exclude:
     - 'test/**/*'
 

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -81,7 +81,7 @@ class RedisClient
       seed = @config.use_replica? && @config.replica_affinity == :random ? nil : Random.new_seed
       pipeline = ::RedisClient::Cluster::Pipeline.new(@router, @command_builder, seed: seed)
       yield pipeline
-      return [] if pipeline.empty? == 0
+      return [] if pipeline.empty?
 
       pipeline.execute
     end

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -10,7 +10,7 @@ class RedisClient
       EMPTY_STRING = ''
 
       class << self
-        def load(nodes) # rubocop:disable Metrics/MethodLength
+        def load(nodes)
           errors = []
           cmd = nil
           nodes&.each do |node|
@@ -82,7 +82,7 @@ class RedisClient
         @details.fetch(name).fetch(key)
       end
 
-      def determine_first_key_position(command) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      def determine_first_key_position(command) # rubocop:disable Metrics/CyclomaticComplexity
         case ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
         when 'eval', 'evalsha', 'zinterstore', 'zunionstore' then 3
         when 'object' then 2

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -32,10 +32,7 @@ class RedisClient
 
         def parse_command_details(rows)
           rows&.reject { |row| row[0].nil? }.to_h do |row|
-            [
-              ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_name(row[0]),
-              { arity: row[1], flags: row[2], first: row[3], last: row[4], step: row[5] }
-            ]
+            [row[0].downcase, { arity: row[1], flags: row[2], first: row[3], last: row[4], step: row[5] }]
           end
         end
       end

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -37,7 +37,7 @@ class RedisClient
       end
 
       class << self
-        def load_info(options, **kwargs) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        def load_info(options, **kwargs) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           startup_size = options.size > MAX_STARTUP_SAMPLE ? MAX_STARTUP_SAMPLE : options.size
           node_info_list = errors = nil
           startup_options = options.to_a.sample(MAX_STARTUP_SAMPLE).to_h
@@ -83,7 +83,7 @@ class RedisClient
 
         # @see https://redis.io/commands/cluster-nodes/
         # @see https://github.com/redis/redis/blob/78960ad57b8a5e6af743d789ed8fd767e37d42b8/src/cluster.c#L4660-L4683
-        def parse_node_info(info) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+        def parse_node_info(info) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           rows = info.split("\n").map(&:split)
           rows.each { |arr| arr[2] = arr[2].split(',') }
           rows.select! { |arr| arr[7] == 'connected' && (arr[2] & %w[fail? fail handshake noaddr noflags]).empty? }
@@ -242,7 +242,7 @@ class RedisClient
         raise ::RedisClient::Cluster::ErrorCollection, errors
       end
 
-      def try_map(clients) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def try_map(clients) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         results = errors = nil
         clients.each_slice(MAX_THREADS) do |chuncked_clients|
           threads = chuncked_clients.map do |k, v|

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -39,7 +39,7 @@ class RedisClient
 
         private
 
-        def measure_latencies(clients) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def measure_latencies(clients) # rubocop:disable Metrics/AbcSize
           clients.each_slice(::RedisClient::Cluster::Node::MAX_THREADS).each_with_object({}) do |chuncked_clients, acc|
             threads = chuncked_clients.map do |k, v|
               Thread.new(k, v) do |node_key, client|

--- a/lib/redis_client/cluster/normalized_cmd_name.rb
+++ b/lib/redis_client/cluster/normalized_cmd_name.rb
@@ -28,6 +28,7 @@ class RedisClient
 
       def clear
         @mutex.synchronize { @cache.clear }
+        true
       end
 
       private

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -71,12 +71,11 @@ class RedisClient
         all_replies = errors = nil
         @pipelines.each_slice(MAX_THREADS) do |chuncked_pipelines|
           threads = chuncked_pipelines.map do |node_key, pipeline|
-            node = @router.find_node(node_key)
-            Thread.new(node, pipeline) do |nd, pl|
+            Thread.new(node_key, pipeline) do |nk, pl|
               Thread.pass
-              Thread.current.thread_variable_set(:node_key, node_key)
-              replies = do_pipelining(nd, pl)
-              raise ReplySizeError, "commands: #{pipeline._size}, replies: #{replies.size}" if pipeline._size != replies.size
+              Thread.current.thread_variable_set(:node_key, nk)
+              replies = do_pipelining(@router.find_node(nk), pl)
+              raise ReplySizeError, "commands: #{pl._size}, replies: #{replies.size}" if pl._size != replies.size
 
               Thread.current.thread_variable_set(:replies, replies)
             rescue StandardError => e

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -68,7 +68,7 @@ class RedisClient
       # TODO: https://github.com/redis-rb/redis-cluster-client/issues/37 handle redirections
       def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         all_replies = errors = nil
-        @pipelines.each_slice(MAX_THREADS) do |chuncked_pipelines|
+        @pipelines&.each_slice(MAX_THREADS) do |chuncked_pipelines|
           threads = chuncked_pipelines.map do |node_key, pipeline|
             Thread.new(node_key, pipeline) do |nk, pl|
               Thread.pass

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -67,7 +67,7 @@ class RedisClient
       end
 
       # TODO: https://github.com/redis-rb/redis-cluster-client/issues/37 handle redirections
-      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         all_replies = errors = nil
         @pipelines.each_slice(MAX_THREADS) do |chuncked_pipelines|
           threads = chuncked_pipelines.map do |node_key, pipeline|

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -15,8 +15,7 @@ class RedisClient
         @router = router
         @command_builder = command_builder
         @seed = seed
-        @pipelines = {}
-        @indices = {}
+        @pipelines = @indices = nil
         @size = 0
       end
 
@@ -103,10 +102,12 @@ class RedisClient
       private
 
       def get_pipeline(node_key)
+        @pipelines ||= {}
         @pipelines[node_key] ||= ::RedisClient::Pipeline.new(@command_builder)
       end
 
       def index_pipeline(node_key)
+        @indices ||= {}
         @indices[node_key] ||= []
         @indices[node_key] << @size
         @size += 1

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -25,7 +25,7 @@ class RedisClient
         @command_builder = @config.command_builder
       end
 
-      def send_command(method, command, *args, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def send_command(method, command, *args, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         cmd = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
         case cmd
         when 'acl', 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
@@ -65,7 +65,7 @@ class RedisClient
 
       # @see https://redis.io/topics/cluster-spec#redirection-and-resharding
       #   Redirection and resharding
-      def try_send(node, method, command, args, retry_count: 3, &block) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def try_send(node, method, command, args, retry_count: 3, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         if args.empty?
           # prevent memory allocation for variable-length args
           node.send(method, command, &block)
@@ -100,7 +100,7 @@ class RedisClient
         retry
       end
 
-      def try_delegate(node, method, *args, retry_count: 3, **kwargs, &block) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def try_delegate(node, method, *args, retry_count: 3, **kwargs, &block) # rubocop:disable Metrics/AbcSize
         node.send(method, *args, **kwargs, &block)
       rescue ::RedisClient::CommandError => e
         raise if retry_count <= 0
@@ -129,7 +129,7 @@ class RedisClient
         retry
       end
 
-      def scan(*command, seed: nil, **kwargs) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def scan(*command, seed: nil, **kwargs) # rubocop:disable Metrics/AbcSize
         command = @command_builder.generate(command, kwargs)
 
         command[1] = ZERO_CURSOR_FOR_SCAN if command.size == 1
@@ -270,7 +270,7 @@ class RedisClient
         find_node(node_key)
       end
 
-      def fetch_cluster_info(config, pool: nil, **kwargs) # rubocop:disable Metrics/MethodLength
+      def fetch_cluster_info(config, pool: nil, **kwargs)
         node_info = ::RedisClient::Cluster::Node.load_info(config.per_node_key, **kwargs)
         node_addrs = node_info.map { |info| ::RedisClient::Cluster::NodeKey.hashify(info[:node_key]) }
         config.update_node(node_addrs)

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -114,7 +114,7 @@ class RedisClient
       end
     end
 
-    def parse_node_url(addr) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+    def parse_node_url(addr) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       return if addr.empty?
 
       uri = URI(addr)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -4,7 +4,7 @@ require 'testing_helper'
 
 class RedisClient
   class TestCluster
-    module Mixin # rubocop:disable Metrics/ModuleLength
+    module Mixin
       def setup
         @client = new_test_client
         @client.call('FLUSHDB')


### PR DESCRIPTION
# Before

```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2856434 bytes (46796 objects)
Total retained:  17520 bytes (438 objects)
```

```
allocated memory by location
-----------------------------------
    546600  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:211
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    144000  redis-cluster-client/lib/redis_client/cluster/pipeline.rb:23
    132384  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:161
    120000  redis-client-0.8.1/lib/redis_client/command_builder.rb:35
    104304  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:54
```

```
allocated memory by class
-----------------------------------
   1410930  String
    990736  Array
    419104  Hash
     19080  Addrinfo
      3888  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```

# After
```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2708945 bytes (44798 objects)
Total retained:  120 bytes (3 objects)
```

```
allocated memory by location
-----------------------------------
    546600  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:97
    262224  redis-cluster-client/lib/redis_client/cluster/node.rb:211
    201240  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:95
    184704  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:147
    182898  redis-client-0.8.1/lib/redis_client/ruby_connection/buffered_io.rb:104
    160280  redis-client-0.8.1/lib/redis_client/command_builder.rb:9
    132384  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:161
    120000  redis-client-0.8.1/lib/redis_client/command_builder.rb:35
    104304  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:54
     80640  redis-client-0.8.1/lib/redis_client/ruby_connection/resp3.rb:38
```

```
allocated memory by class
-----------------------------------
   1406753  String
    846736  Array
    419776  Hash
     19080  Addrinfo
      3888  Thread
      2832  MatchData
      2160  Socket
      1752  RedisClient::Cluster::Node::Config
       936  RedisClient
       880  Proc
```