### PR TITLE
perf: use struct instead of hash for memory consumption

### DIFF
--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -31,7 +31,7 @@ class RedisClient
         end
       end
 
-      def test_parse_command_details
+      def test_parse_command_reply
         [
           {
             rows: [
@@ -56,7 +56,7 @@ class RedisClient
           { rows: nil, want: {} }
         ].each_with_index do |c, idx|
           msg = "Case: #{idx}"
-          got = ::RedisClient::Cluster::Command.send(:parse_command_details, c[:rows])
+          got = ::RedisClient::Cluster::Command.send(:parse_command_reply, c[:rows])
           assert_equal(c[:want].size, got.size, msg)
           assert_equal(c[:want].keys.sort, got.keys.sort, msg)
           c[:want].each do |k, v|

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -32,7 +32,6 @@ class RedisClient
       end
 
       def test_parse_command_details
-        keys = %i[arity flags first last step].freeze
         [
           {
             rows: [
@@ -40,8 +39,8 @@ class RedisClient
               ['set', -3, Set['write', 'denyoom', 'movablekeys'], 1, 1, 1, Set['@write', '@string', '@slow'], Set[], Set[], Set[]]
             ],
             want: {
-              'get' => { arity: 2, flags: Set['readonly', 'fast'], first: 1, last: 1, step: 1 },
-              'set' => { arity: -3, flags: Set['write', 'denyoom', 'movablekeys'], first: 1, last: 1, step: 1 }
+              'get' => { first_key_position: 1, write?: false, readonly?: true },
+              'set' => { first_key_position: 1, write?: true, readonly?: false }
             }
           },
           {
@@ -49,7 +48,7 @@ class RedisClient
               ['GET', 2, Set['readonly', 'fast'], 1, 1, 1, Set['@read', '@string', '@fast'], Set[], Set[], Set[]]
             ],
             want: {
-              'get' => { arity: 2, flags: Set['readonly', 'fast'], first: 1, last: 1, step: 1 }
+              'get' => { first_key_position: 1, write?: false, readonly?: true }
             }
           },
           { rows: [[]], want: {} },
@@ -60,8 +59,8 @@ class RedisClient
           got = ::RedisClient::Cluster::Command.send(:parse_command_details, c[:rows])
           assert_equal(c[:want].size, got.size, msg)
           assert_equal(c[:want].keys.sort, got.keys.sort, msg)
-          c[:want].each do |k1, v|
-            keys.each { |k2| assert_equal(v[k2], got[k1][k2], "#{msg}: #{k2}") }
+          c[:want].each do |k, v|
+            assert_equal(v, got[k].to_h, "#{msg}: #{k}")
           end
         end
       end
@@ -131,60 +130,6 @@ class RedisClient
           msg = "Case: #{idx}"
           got = cmd.exists?(c[:name])
           assert_equal(c[:want], got, msg)
-        end
-      end
-
-      def test_pick_details
-        keys = %i[first_key_position write readonly].freeze
-        [
-          {
-            details: {
-              'get' => { arity: 2, flags: Set['readonly', 'fast'], first: 1, last: 1, step: 1 },
-              'set' => { arity: -3, flags: Set['write', 'denyoom', 'movablekeys'], first: 1, last: 1, step: 1 }
-            },
-            want: {
-              'get' => { first_key_position: 1, write: false, readonly: true },
-              'set' => { first_key_position: 1, write: true, readonly: false }
-            }
-          },
-          { details: {}, want: {} },
-          { details: nil, want: {} }
-        ].each_with_index do |c, idx|
-          msg = "Case: #{idx}"
-          cmd = ::RedisClient::Cluster::Command.new(c[:details])
-          got = cmd.send(:pick_details, c[:details])
-          assert_equal(c[:want].size, got.size, msg)
-          assert_equal(c[:want].keys.sort, got.keys.sort, msg)
-          c[:want].each do |k1, v|
-            keys.each { |k2| assert_equal(v[k2], got[k1][k2], "#{msg}: #{k2}") }
-          end
-        end
-      end
-
-      def test_dig_details
-        cmd = ::RedisClient::Cluster::Command.new(
-          {
-            'get' => { arity: 2, flags: Set['readonly', 'fast'], first: 1, last: 1, step: 1 },
-            'set' => { arity: -3, flags: Set['write', 'denyoom', 'movablekeys'], first: 1, last: 1, step: 1 }
-          }
-        )
-        [
-          { params: { command: %w[SET foo 1], key: :first_key_position }, want: 1 },
-          { params: { command: %w[SET foo 1], key: :write }, want: true },
-          { params: { command: %w[set foo 1], key: :write }, want: true },
-          { params: { command: %w[SET foo 1], key: :readonly }, want: false },
-          { params: { command: %w[GET foo], key: :first_key_position }, want: 1 },
-          { params: { command: %w[GET foo], key: :write }, want: false },
-          { params: { command: %w[GET foo], key: :readonly }, want: true },
-          { params: { command: %w[get foo], key: :readonly }, want: true },
-          { params: { command: %w[UNKNOWN foo], key: :readonly }, want: nil },
-          { params: { command: [['SET'], 'foo', 1], key: :write }, want: true },
-          { params: { command: [], key: :readonly }, want: nil },
-          { params: { command: nil, key: :readonly }, want: nil }
-        ].each_with_index do |c, idx|
-          msg = "Case: #{idx}"
-          got = cmd.send(:dig_details, c[:params][:command], c[:params][:key])
-          c[:want].nil? ? assert_nil(got, msg) : assert_equal(c[:want], got, msg)
         end
       end
 


### PR DESCRIPTION
* #137

# Before
```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2721324 bytes (44800 objects)
Total retained:  120 bytes (3 objects)
```

```
allocated memory by gem
-----------------------------------
   1883950  redis-client-0.9.0
    565500  redis-cluster-client/lib
    160928  other
    110946  x64/lib
```

```
allocated memory by file
-----------------------------------
    792800  redis-client-0.9.0/lib/redis_client/ruby_connection/resp3.rb
    779022  redis-client-0.9.0/lib/redis_client/ruby_connection/buffered_io.rb
    352676  redis-cluster-client/lib/redis_client/cluster/node.rb
    280280  redis-client-0.9.0/lib/redis_client/command_builder.rb
    160440  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
    124880  redis-cluster-client/lib/redis_client/cluster/command.rb
    100530  x64/lib/ruby/3.1.0/socket.rb
     59232  redis-cluster-client/lib/redis_client/cluster/pipeline.rb
     27672  redis-client-0.9.0/lib/redis_client.rb
     12416  redis-cluster-client/lib/redis_client/cluster_config.rb
```

```
allocated memory by class
-----------------------------------
   1419164  String
    846736  Array
    419608  Hash
     19080  Addrinfo
      3888  Thread
      2832  MatchData
      2160  Socket
      1816  RedisClient::Cluster::Node::Config
      1008  RedisClient
       880  Proc
```

# After
```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2720333 bytes (44802 objects)
Total retained:  120 bytes (3 objects)
```

```
allocated memory by gem
-----------------------------------
   1908532  redis-client-0.9.0
    527516  redis-cluster-client/lib
    160928  other
    123357  x64/lib
```

```
allocated memory by file
-----------------------------------
    803604  redis-client-0.9.0/lib/redis_client/ruby_connection/buffered_io.rb
    792800  redis-client-0.9.0/lib/redis_client/ruby_connection/resp3.rb
    352676  redis-cluster-client/lib/redis_client/cluster/node.rb
    280280  redis-client-0.9.0/lib/redis_client/command_builder.rb
    160440  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
    112941  x64/lib/ruby/3.1.0/socket.rb
     86896  redis-cluster-client/lib/redis_client/cluster/command.rb
     59232  redis-cluster-client/lib/redis_client/cluster/pipeline.rb
     27672  redis-client-0.9.0/lib/redis_client.rb
     12416  redis-cluster-client/lib/redis_client/cluster_config.rb
```

```
allocated memory by class
-----------------------------------
   1456157  String
    846736  Array
    372024  Hash
     19080  Addrinfo
      9600  Struct::RedisCommand
      3888  Thread
      2832  MatchData
      2160  Socket
      1816  RedisClient::Cluster::Node::Config
      1008  RedisClient
```