### PR TITLE
perf: optimize memory allocation for slot-node-mapping array

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -44,7 +44,12 @@ class RedisClient
 
         def []=(slot, primary_node_key)
           index = primary_node_keys.find_index(primary_node_key)
-          raise(::RedisClient::Cluster::Node::ReloadNeeded, primary_node_key) if index.nil?
+          if index.nil?
+            raise(::RedisClient::Cluster::Node::ReloadNeeded, primary_node_key) if primary_node_keys.size >= SLOT_OPTIMIZATION_MAX_SHARD_SIZE
+
+            index = primary_node_keys.size
+            primary_node_keys << primary_node_key
+          end
 
           slots.setbyte(slot, index)
         end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -372,6 +372,40 @@ class RedisClient
         end
       end
 
+      def test_make_array_for_slot_node_mappings_optimized
+        node_info_list = Array.new(256) do |i|
+          ::RedisClient::Cluster::Node::Info.new(
+            node_key: "127.0.0.1:#{1024 + i + 1}",
+            role: 'master'
+          )
+        end
+
+        want = node_info_list.first.node_key
+        got = @test_node.send(:make_array_for_slot_node_mappings, node_info_list)
+        assert_instance_of(Struct::RedisSlot, got)
+        ::RedisClient::Cluster::Node::SLOT_SIZE.times do |i|
+          got[i] = want
+          assert_equal(want, got[i], "Case: #{i}")
+        end
+      end
+
+      def test_make_array_for_slot_node_mappings_unoptimized
+        node_info_list = Array.new(257) do |i|
+          ::RedisClient::Cluster::Node::Info.new(
+            node_key: "127.0.0.1:#{1024 + i + 1}",
+            role: 'master'
+          )
+        end
+
+        want = node_info_list.first.node_key
+        got = @test_node.send(:make_array_for_slot_node_mappings, node_info_list)
+        assert_instance_of(Array, got)
+        ::RedisClient::Cluster::Node::SLOT_SIZE.times do |i|
+          got[i] = want
+          assert_equal(want, got[i], "Case: #{i}")
+        end
+      end
+
       def test_build_replication_mappings_regular
         node_key1 = '127.0.0.1:7001'
         node_key2 = '127.0.0.1:7002'

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -334,7 +334,7 @@ class RedisClient
       def test_update_slot
         sample_slot = 0
         base_node_key = @test_node.find_node_key_of_primary(sample_slot)
-        another_node_key = @test_node_info_list.find { |info| info.node_key != base_node_key && info.primary? }
+        another_node_key = @test_node_info_list.find { |info| info.node_key != base_node_key && info.primary? }&.node_key
         @test_node.update_slot(sample_slot, another_node_key)
         assert_equal(another_node_key, @test_node.find_node_key_of_primary(sample_slot))
       end
@@ -353,12 +353,12 @@ class RedisClient
 
       def test_build_slot_node_mappings
         node_info_list = [
-          { node_key: '127.0.0.1:7001', slots: [[0, 3000], [3002, 5460], [15_001, 15_001]] },
-          { node_key: '127.0.0.1:7002', slots: [[3001, 3001], [5461, 7000], [7002, 10_922]] },
-          { node_key: '127.0.0.1:7003', slots: [[7001, 7001], [10_923, 15_000], [15_002, 16_383]] },
-          { node_key: '127.0.0.1:7004', slots: [] },
-          { node_key: '127.0.0.1:7005', slots: [] },
-          { node_key: '127.0.0.1:7006', slots: [] }
+          { node_key: '127.0.0.1:7001', role: 'master', slots: [[0, 3000], [3002, 5460], [15_001, 15_001]] },
+          { node_key: '127.0.0.1:7002', role: 'master', slots: [[3001, 3001], [5461, 7000], [7002, 10_922]] },
+          { node_key: '127.0.0.1:7003', role: 'master', slots: [[7001, 7001], [10_923, 15_000], [15_002, 16_383]] },
+          { node_key: '127.0.0.1:7004', role: 'slave', slots: [] },
+          { node_key: '127.0.0.1:7005', role: 'slave', slots: [] },
+          { node_key: '127.0.0.1:7006', role: 'slave', slots: [] }
         ].map { |info| ::RedisClient::Cluster::Node::Info.new(**info) }
 
         got = @test_node.send(:build_slot_node_mappings, node_info_list)


### PR DESCRIPTION
closes #137

# Before
```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2747715 bytes (44836 objects)
Total retained:  120 bytes (3 objects)
```

```
allocated memory by gem
-----------------------------------
   1941308  redis-client-0.9.0
    530396  redis-cluster-client/lib
    160928  other
    115083  x64/lib
```

```
allocated memory by file
-----------------------------------
    836380  redis-client-0.9.0/lib/redis_client/ruby_connection/buffered_io.rb
    792800  redis-client-0.9.0/lib/redis_client/ruby_connection/resp3.rb
    355556  redis-cluster-client/lib/redis_client/cluster/node.rb
    280280  redis-client-0.9.0/lib/redis_client/command_builder.rb
    160440  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
    104667  x64/lib/ruby/3.1.0/socket.rb
     86896  redis-cluster-client/lib/redis_client/cluster/command.rb
     59232  redis-cluster-client/lib/redis_client/cluster/pipeline.rb
     27672  redis-client-0.9.0/lib/redis_client.rb
     12416  redis-cluster-client/lib/redis_client/cluster_config.rb
     10280  redis-cluster-client/lib/redis_client/cluster/node/primary_only.rb
      7824  x64/lib/ruby/3.1.0/uri/rfc3986_parser.rb
      3120  redis-cluster-client/lib/redis_client/cluster/node_key.rb
      2376  redis-client-0.9.0/lib/redis_client/ruby_connection.rb
      1872  x64/lib/ruby/3.1.0/uri/common.rb
      1440  redis-client-0.9.0/lib/redis_client/config.rb
      1112  redis-cluster-client/lib/redis_client/cluster/router.rb
       888  redis-cluster-client/lib/redis_client/cluster.rb
       720  x64/lib/ruby/3.1.0/uri/generic.rb
       624  redis-cluster-client/lib/redis_cluster_client.rb
```

```
allocated memory by class
-----------------------------------
   1480659  String
    846736  Array
    370872  Hash
     19080  Addrinfo
      9600  Struct::RedisCommand
      4032  Struct::RedisNode
      3888  Thread
      2832  MatchData
      2160  Socket
      1816  RedisClient::Cluster::Node::Config
      1008  RedisClient
       880  Proc
       864  RedisClient::RubyConnection::BufferedIO
       720  URI::Generic
       408  Enumerator
       360  Range
       360  RedisClient::RubyConnection
       360  Thread::Mutex
       288  RedisClient::Cluster::Pipeline::Extended
       224  RedisClient::ClusterConfig
```

# After
```
################################################################################
# primary_only: w/ pipelining
################################################################################

Total allocated: 2454045 bytes (44847 objects)
Total retained:  120 bytes (3 objects)
```

```
allocated memory by gem
-----------------------------------
   1879853  redis-client-0.9.0
    302318  redis-cluster-client/lib
    160928  other
    110946  x64/lib
```

```
allocated memory by file
-----------------------------------
    792800  redis-client-0.9.0/lib/redis_client/ruby_connection/resp3.rb
    774925  redis-client-0.9.0/lib/redis_client/ruby_connection/buffered_io.rb
    280280  redis-client-0.9.0/lib/redis_client/command_builder.rb
    160440  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
    127478  redis-cluster-client/lib/redis_client/cluster/node.rb
    100530  x64/lib/ruby/3.1.0/socket.rb
     86896  redis-cluster-client/lib/redis_client/cluster/command.rb
     59232  redis-cluster-client/lib/redis_client/cluster/pipeline.rb
     27672  redis-client-0.9.0/lib/redis_client.rb
     12416  redis-cluster-client/lib/redis_client/cluster_config.rb
     10280  redis-cluster-client/lib/redis_client/cluster/node/primary_only.rb
      7824  x64/lib/ruby/3.1.0/uri/rfc3986_parser.rb
      3120  redis-cluster-client/lib/redis_client/cluster/node_key.rb
      2376  redis-client-0.9.0/lib/redis_client/ruby_connection.rb
      1872  x64/lib/ruby/3.1.0/uri/common.rb
      1440  redis-client-0.9.0/lib/redis_client/config.rb
      1112  redis-cluster-client/lib/redis_client/cluster/router.rb
       888  redis-cluster-client/lib/redis_client/cluster.rb
       720  x64/lib/ruby/3.1.0/uri/generic.rb
       624  redis-cluster-client/lib/redis_cluster_client.rb
```

```
allocated memory by class
-----------------------------------
   1447917  String
    584720  Array
    371880  Hash
     19080  Addrinfo
      9600  Struct::RedisCommand
      4032  Struct::RedisNode
      3888  Thread
      2832  MatchData
      2160  Socket
      1816  RedisClient::Cluster::Node::Config
      1008  RedisClient
       880  Proc
       864  RedisClient::RubyConnection::BufferedIO
       720  URI::Generic
       408  Enumerator
       360  Range
       360  RedisClient::RubyConnection
       360  Thread::Mutex
       288  RedisClient::Cluster::Pipeline::Extended
       224  RedisClient::ClusterConfig
```