### PR TITLE
perf: don't immediately Thread.pass in Pipeline#execute when there is work to do

### DIFF
--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -142,7 +142,6 @@ class RedisClient
         @pipelines&.each_slice(MAX_THREADS) do |chuncked_pipelines|
           threads = chuncked_pipelines.map do |node_key, pipeline|
             Thread.new(node_key, pipeline) do |nk, pl|
-              Thread.pass
               Thread.current.thread_variable_set(:node_key, nk)
               replies = do_pipelining(@router.find_node(nk), pl)
               raise ReplySizeError, "commands: #{pl._size}, replies: #{replies.size}" if pl._size != replies.size


### PR DESCRIPTION
When a pipeline is executed each thread that is spawned immediately hints to the scheduler it should pass execution to another thread before it attempts to do any work. I was unsure of the reason for this and thought it might be causing unnecessary context switches and/or other overhead. I attempted to do quick look through the gem's history to see if there was a specific reason for using `Thread.pass` but didn't notice any. I wanted to benchmark the throughput of running a pipeline with and without thread pass so I put together the following benchmark:

```ruby

require 'benchmark/ips'
require 'redis-cluster-client'
rc = RedisClient.cluster(nodes: ['redis://node1:6379']).new_client

PIPE_GET_KEYS = %w[test_1 test_2 test_3 test_4 test_5 test_6 test_7 test_8 test_9 test_10]
PIPE_GET_VALUES = %w[value_1 value_2 value_3 value_4 value_5 value_6 value_7 value_8 value_9 value_10]

PIPE_GET_KEYS.each_with_index { |key, i| rc.set(key, PIPE_GET_VALUES[i]) }

Benchmark.ips do |x|
  x.report('Thread.pass') do
    rc.pipelined do |pipe|
      PIPE_GET_KEYS.each { |key| pipe.call('GET', key) }
    end
  end
  x.report('No Thread.pass') do
    rc.pipelined do |pipe|
      PIPE_GET_KEYS.each { |key| pipe.call('GET', key) }
    end
  end

  x.time = 10
  x.stats = :bootstrap
  x.confidence = 95
  x.hold! 'bench1'
  x.compare!
end
```

I ran the benchmark in a ruby 2.7 docker container networked with the cluster configuration that's used for tests. This was run on an arm64 host system. The results were as follows:

```
Warming up --------------------------------------
      No Thread.pass   284.000  i/100ms
Calculating -------------------------------------
      No Thread.pass      2.799k (± 0.9%) i/s -     28.116k in  10.068159s
                   with 95.0% confidence

Comparison:
      No Thread.pass:     2799.2 i/s
         Thread.pass:     2553.8 i/s - 1.10x  (± 0.01) slower
                   with 95.0% confidence
```