### PR TITLE
perf: faster extract_hash_tag

### DIFF
--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -7,9 +7,9 @@ require 'redis_client/cluster/normalized_cmd_name'
 class RedisClient
   class Cluster
     class Command
-      EMPTY_STRING = "".freeze
-      LEFT_BRACKET = "{".freeze
-      RIGHT_BRACKET = "}".freeze
+      EMPTY_STRING = ''
+      LEFT_BRACKET = '{'
+      RIGHT_BRACKET = '}'
 
       Detail = Struct.new(
         'RedisCommand',
@@ -106,10 +106,9 @@ class RedisClient
       # @see https://redis.io/topics/cluster-spec#keys-hash-tags Keys hash tags
       def extract_hash_tag(key)
         key = key.to_s
-        
         s = key.index(LEFT_BRACKET)
         return EMPTY_STRING if s.nil?
-        
+
         e = key.index(RIGHT_BRACKET, s + 1)
         return EMPTY_STRING if e.nil?
 

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -7,7 +7,9 @@ require 'redis_client/cluster/normalized_cmd_name'
 class RedisClient
   class Cluster
     class Command
-      EMPTY_STRING = ''
+      EMPTY_STRING = "".freeze
+      LEFT_BRACKET = "{".freeze
+      RIGHT_BRACKET = "}".freeze
 
       Detail = Struct.new(
         'RedisCommand',
@@ -104,8 +106,8 @@ class RedisClient
       # @see https://redis.io/topics/cluster-spec#keys-hash-tags Keys hash tags
       def extract_hash_tag(key)
         key = key.to_s
-        s = key.index('{')
-        e = key.index('}', s.to_i + 1)
+        s = key.index(LEFT_BRACKET)
+        e = key.index(RIGHT_BRACKET, s.to_i + 1)
 
         return EMPTY_STRING if s.nil? || e.nil?
 

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -106,10 +106,12 @@ class RedisClient
       # @see https://redis.io/topics/cluster-spec#keys-hash-tags Keys hash tags
       def extract_hash_tag(key)
         key = key.to_s
+        
         s = key.index(LEFT_BRACKET)
-        e = key.index(RIGHT_BRACKET, s.to_i + 1)
-
-        return EMPTY_STRING if s.nil? || e.nil?
+        return EMPTY_STRING if s.nil?
+        
+        e = key.index(RIGHT_BRACKET, s + 1)
+        return EMPTY_STRING if e.nil?
 
         key[s + 1..e - 1]
       end


### PR DESCRIPTION
Use frozen strings for `extract_hash_tag`

```
require "benchmark/ips"
require "securerandom"

EMPTY_STRING = "".freeze
LEFT_BRACKET = "{".freeze
RIGHT_BRACKET = "}".freeze

def random_key
  (rand * 10).to_i % 2 == 0 ? SecureRandom.hex(32) : "{" << SecureRandom.hex(32) << "}"
end

def slow
  100000.times {

    key = random_key
    
    s = key.index('{')
    e = key.index('}', s.to_i + 1)
    
    return EMPTY_STRING if s.nil? || e.nil?
    
    key[s + 1..e - 1]
  }
end

def fast
  100000.times {

    key = random_key
    
    s = key.index(LEFT_BRACKET)
    return EMPTY_STRING if s.nil?
    
    e = key.index(RIGHT_BRACKET, s + 1)
    return EMPTY_STRING if e.nil?

    key[s + 1..e - 1]
  }
end

Benchmark.ips do |x|
  x.report("fast") { fast }
  x.report("slow") { slow }
  x.compare!
end
```

Result:

```
Warming up --------------------------------------
                fast    54.463k i/100ms
                slow    49.849k i/100ms
Calculating -------------------------------------
                fast    546.699k (± 0.5%) i/s -      2.778M in   5.080809s
                slow    498.325k (± 0.4%) i/s -      2.492M in   5.001730s

Comparison:
                fast:   546699.0 i/s
                slow:   498324.8 i/s - 1.10x  (± 0.00) slower
```
