### PR TITLE
fix: pipelined broken due to redis-client v0.10

### DIFF
--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -200,7 +200,7 @@ class RedisClient
       def send_pipeline(client, pipeline)
         results = client.send(:ensure_connected, retryable: pipeline._retryable?) do |connection|
           commands = pipeline._commands
-          ::RedisClient::Middlewares.call_pipelined(commands, client.config) do
+          client.instance_variable_get(:@middlewares).call_pipelined(commands, client.config) do
             connection.call_pipelined_aware_of_redirection(commands, pipeline._timeouts)
           end
         end

--- a/redis-cluster-client.gemspec
+++ b/redis-cluster-client.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.metadata['allowed_push_host']     = 'https://rubygems.org'
   s.files                             = Dir['lib/**/*.rb']
 
-  s.add_runtime_dependency 'redis-client', '~> 0.6'
+  s.add_runtime_dependency 'redis-client', '>= 0.10'
 end


### PR DESCRIPTION
* #166

> undefined method `call_pipelined' for RedisClient::Middlewares:Class