### PR TITLE
ci: bump redis server version from 7.0.1 to 7.0.5 for testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ['7.0.1', '6.2.7']
+        redis: ['7.0.5', '6.2.7']
         ruby: ['3.1', '3.0', '2.7']
         driver: ['ruby', 'hiredis']
         docker: ['compose.yaml', 'compose.ssl.yaml']
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      REDIS_VERSION: '7.0.1'
+      REDIS_VERSION: '7.0.5'
       REDIS_REPLICA_SIZE: '2'
       DOCKER_COMPOSE_FILE: 'compose.replica.yaml'
     steps:
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ['7.0.1', '6.2.7']
+        redis: ['7.0.5', '6.2.7']
     runs-on: ubuntu-latest
     env:
       REDIS_VERSION: ${{ matrix.redis }}
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ['7.0.1', '6.2.7']
+        redis: ['7.0.5', '6.2.7']
     runs-on: ubuntu-latest
     env:
       REDIS_VERSION: ${{ matrix.redis }}
@@ -196,7 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ['7.0.1', '6.2.7']
+        redis: ['7.0.5', '6.2.7']
     runs-on: ubuntu-latest
     env:
       REDIS_VERSION: ${{ matrix.redis }}
@@ -228,7 +228,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      REDIS_VERSION: '7.0.1'
+      REDIS_VERSION: '7.0.5'
       DOCKER_COMPOSE_FILE: 'compose.nat.yaml'
     steps:
       - name: Check out code
@@ -288,7 +288,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      REDIS_VERSION: '7.0.1'
+      REDIS_VERSION: '7.0.5'
       DOCKER_COMPOSE_FILE: 'compose.latency.yaml'
       REDIS_REPLICA_SIZE: '2'
       REDIS_CLIENT_MAX_THREADS: '5'
@@ -352,7 +352,7 @@ jobs:
         mode: ['single', 'excessive_pipelining', 'pipelining_in_moderation']
     runs-on: ubuntu-latest
     env:
-      REDIS_VERSION: '7.0.1'
+      REDIS_VERSION: '7.0.5'
       DOCKER_COMPOSE_FILE: 'compose.yaml'
     steps:
       - name: Check out code


### PR DESCRIPTION
* https://github.com/redis/redis/releases/tag/7.0.5
* https://github.com/redis/redis/releases/tag/7.0.4
* https://github.com/redis/redis/releases/tag/7.0.3
* https://github.com/redis/redis/releases/tag/7.0.2