### PR TITLE
fix: SCRIPT EXISTS must check all nodes

### DIFF
--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -260,7 +260,7 @@ class RedisClient
           i = -1
           loop do
             i += 1
-            break if responses[i].nil?
+            break if responses[0][i].nil?
 
             final_response << (responses.all? { |r| r[i].eql?(1) } ? 1 : 0)
           end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -255,16 +255,7 @@ class RedisClient
           @node.call_all(method, command, args, &block).first
         when 'exists'
           # check for existence on all nodes
-          responses = @node.call_all(method, command, args, &block)
-          final_response = []
-          i = -1
-          loop do
-            i += 1
-            break if responses[0][i].nil?
-
-            final_response << (responses.all? { |r| r[i].eql?(1) } ? 1 : 0)
-          end
-          final_response
+          @node.call_all(method, command, args, &block).transpose.map { |arr| arr.any?(&:zero?) ? 0 : 1 }
         when 'flush', 'load'
           @node.call_primaries(method, command, args, &block).first
         else assign_node(command).public_send(method, *args, command, &block)

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -249,23 +249,21 @@ class RedisClient
         end
       end
 
-      def send_script_command(method, command, args, &block)
+      def send_script_command(method, command, args, &block) # rubocop:disable Metrics/AbcSize
         case ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_subcommand(command)
         when 'debug', 'kill'
           @node.call_all(method, command, args, &block).first
         when 'exists'
           # check for existence on all nodes
           responses = @node.call_all(method, command, args, &block)
-          
           final_response = []
-          
           i = -1
           loop do
             i += 1
             break if responses[i].nil?
-            final_response << (responses.all?{|r| r[i].eql?(1)} ? 1 : 0)
+
+            final_response << (responses.all? { |r| r[i].eql?(1) } ? 1 : 0)
           end
-          
           final_response
         when 'flush', 'load'
           @node.call_primaries(method, command, args, &block).first

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -249,7 +249,7 @@ class RedisClient
         end
       end
 
-      def send_script_command(method, command, args, &block) # rubocop:disable Metrics/AbcSize
+      def send_script_command(method, command, args, &block)
         case ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_subcommand(command)
         when 'debug', 'kill'
           @node.call_all(method, command, args, &block).first

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -263,7 +263,7 @@ class RedisClient
           loop do
             i += 1
             break if responses[i].nil?
-            final_response << (responses.map{|r| r[i]}.all?{|r| r.eql?(1)} ? 1 : 0)
+            final_response << (responses.all?{|r| r[i].eql?(1)} ? 1 : 0)
           end
           
           final_response

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -242,6 +242,7 @@ class RedisClient
           { command: %w[SCRIPT DEBUG NO], want: 'OK' },
           { command: %w[SCRIPT FLUSH], want: 'OK' },
           { command: %w[SCRIPT EXISTS b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c], want: [0] },
+          { command: %w[SCRIPT EXISTS 31b6de18e43fe980ed07d8b0f5a8cabe 5b9fb3410653a731f8ddfeff39a0c061], want: [0, 0] },
           { command: %w[PUBSUB CHANNELS test-channel*], want: [] },
           { command: %w[PUBSUB NUMSUB test-channel], want: { 'test-channel' => 0 } },
           { command: %w[PUBSUB NUMPAT], want: 0 },


### PR DESCRIPTION
`SCRIPT EXISTS <sha>` returns faulty response in cases where a node has restarted and does not have the script in its cache.
