### PR TITLE
fix: SCRIPT EXISTS must check all nodes

### DIFF
--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -255,6 +255,8 @@ class RedisClient
           @node.call_all(method, command, args, &block).first
         when 'flush', 'load'
           @node.call_primaries(method, command, args, &block).first
+        when 'exists'
+          @node.call_all(method, command, args, &block).transpose.map { |arr| arr.any?(&:zero?) ? 0 : 1 }
         else assign_node(command).public_send(method, *args, command, &block)
         end
       end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -242,6 +242,7 @@ class RedisClient
           { command: %w[SCRIPT DEBUG NO], want: 'OK' },
           { command: %w[SCRIPT FLUSH], want: 'OK' },
           { command: %w[SCRIPT EXISTS b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c], want: [0] },
+          { command: %w[SCRIPT EXISTS 5b9fb3410653a731f8ddfeff39a0c061 31b6de18e43fe980ed07d8b0f5a8cabe], want: [0, 0] },
           { command: %w[PUBSUB CHANNELS test-channel*], want: [] },
           { command: %w[PUBSUB NUMSUB test-channel], want: { 'test-channel' => 0 } },
           { command: %w[PUBSUB NUMPAT], want: 0 },


### PR DESCRIPTION
`SCRIPT EXISTS sha1 sha2 ...` must check all nodes. If a node has lost the script from its cache (a node restarted, etc.) we should know about it.