### PR TITLE
fix: use fiber local storage instead of thread local storage

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -85,11 +85,11 @@ class RedisClient
           startup_nodes.each_slice(MAX_THREADS).with_index do |chuncked_startup_nodes, chuncked_idx|
             threads = chuncked_startup_nodes.each_with_index.map do |raw_client, idx|
               Thread.new(raw_client, (MAX_THREADS * chuncked_idx) + idx) do |cli, i|
-                Thread.current.thread_variable_set(:index, i)
+                Thread.current[:index] = i
                 reply = cli.call('CLUSTER', 'NODES')
-                Thread.current.thread_variable_set(:info, parse_cluster_node_reply(reply))
+                Thread.current[:info] = parse_cluster_node_reply(reply)
               rescue StandardError => e
-                Thread.current.thread_variable_set(:error, e)
+                Thread.current[:error] = e
               ensure
                 cli&.close
               end
@@ -303,11 +303,11 @@ class RedisClient
         clients.each_slice(MAX_THREADS) do |chuncked_clients|
           threads = chuncked_clients.map do |k, v|
             Thread.new(k, v) do |node_key, client|
-              Thread.current.thread_variable_set(:node_key, node_key)
+              Thread.current[:node_key] = node_key
               reply = yield(node_key, client)
-              Thread.current.thread_variable_set(:result, reply)
+              Thread.current[:result] = reply
             rescue StandardError => e
-              Thread.current.thread_variable_set(:error, e)
+              Thread.current[:error] = e
             end
           end
 

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -99,10 +99,10 @@ class RedisClient
               t.join
               if t.thread_variable?(:info)
                 node_info_list ||= Array.new(startup_size)
-                node_info_list[t.thread_variable_get(:index)] = t.thread_variable_get(:info)
+                node_info_list[t[:index]] = t[:info]
               elsif t.thread_variable?(:error)
                 errors ||= Array.new(startup_size)
-                errors[t.thread_variable_get(:index)] = t.thread_variable_get(:error)
+                errors[t[:index]] = t[:error]
               end
             end
           end
@@ -315,10 +315,10 @@ class RedisClient
             t.join
             if t.thread_variable?(:result)
               results ||= {}
-              results[t.thread_variable_get(:node_key)] = t.thread_variable_get(:result)
+              results[t[:node_key]] = t[:result]
             elsif t.thread_variable?(:error)
               errors ||= {}
-              errors[t.thread_variable_get(:node_key)] = t.thread_variable_get(:error)
+              errors[t[:node_key]] = t[:error]
             end
           end
         end

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -97,10 +97,10 @@ class RedisClient
 
             threads.each do |t|
               t.join
-              if t.thread_variable?(:info)
+              if t.key?(:info)
                 node_info_list ||= Array.new(startup_size)
                 node_info_list[t[:index]] = t[:info]
-              elsif t.thread_variable?(:error)
+              elsif t.key?(:error)
                 errors ||= Array.new(startup_size)
                 errors[t[:index]] = t[:error]
               end
@@ -313,10 +313,10 @@ class RedisClient
 
           threads.each do |t|
             t.join
-            if t.thread_variable?(:result)
+            if t.key?(:result)
               results ||= {}
               results[t[:node_key]] = t[:result]
-            elsif t.thread_variable?(:error)
+            elsif t.key?(:error)
               errors ||= {}
               errors[t[:node_key]] = t[:error]
             end

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -43,7 +43,7 @@ class RedisClient
           clients.each_slice(::RedisClient::Cluster::Node::MAX_THREADS).each_with_object({}) do |chuncked_clients, acc|
             threads = chuncked_clients.map do |k, v|
               Thread.new(k, v) do |node_key, client|
-                Thread.current.thread_variable_set(:node_key, node_key)
+                Thread.current[:node_key] = node_key
 
                 min = DUMMY_LATENCY_NSEC
                 MEASURE_ATTEMPT_COUNT.times do
@@ -53,9 +53,9 @@ class RedisClient
                   min = duration if duration < min
                 end
 
-                Thread.current.thread_variable_set(:latency, min)
+                Thread.current[:latency] = min
               rescue StandardError
-                Thread.current.thread_variable_set(:latency, DUMMY_LATENCY_NSEC)
+                Thread.current[:latency] = DUMMY_LATENCY_NSEC
               end
             end
 

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -61,7 +61,7 @@ class RedisClient
 
             threads.each do |t|
               t.join
-              acc[t.thread_variable_get(:node_key)] = t.thread_variable_get(:latency)
+              acc[t[:node_key]] = t[:latency]
             end
           end
         end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -164,18 +164,18 @@ class RedisClient
 
           threads.each(&:join)
           threads.each do |t|
-            if t.thread_variable?(:replies)
+            if t.key?(:replies)
               all_replies ||= Array.new(@size)
               @pipelines[t[:node_key]]
                 .outer_indices
                 .each_with_index { |outer, inner| all_replies[outer] = t[:replies][inner] }
-            elsif t.thread_variable?(:redirection_needed)
+            elsif t.key?(:redirection_needed)
               all_replies ||= Array.new(@size)
               pipeline = @pipelines[t[:node_key]]
               err = t[:redirection_needed]
               err.indices.each { |i| err.replies[i] = handle_redirection(err.replies[i], pipeline, i) }
               pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = err.replies[inner] }
-            elsif t.thread_variable?(:error)
+            elsif t.key?(:error)
               errors ||= {}
               errors[t[:node_key]] = t[:error]
             end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -166,18 +166,18 @@ class RedisClient
           threads.each do |t|
             if t.thread_variable?(:replies)
               all_replies ||= Array.new(@size)
-              @pipelines[t.thread_variable_get(:node_key)]
+              @pipelines[t[:node_key]]
                 .outer_indices
-                .each_with_index { |outer, inner| all_replies[outer] = t.thread_variable_get(:replies)[inner] }
+                .each_with_index { |outer, inner| all_replies[outer] = t[:replies][inner] }
             elsif t.thread_variable?(:redirection_needed)
               all_replies ||= Array.new(@size)
-              pipeline = @pipelines[t.thread_variable_get(:node_key)]
-              err = t.thread_variable_get(:redirection_needed)
+              pipeline = @pipelines[t[:node_key]]
+              err = t[:redirection_needed]
               err.indices.each { |i| err.replies[i] = handle_redirection(err.replies[i], pipeline, i) }
               pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = err.replies[inner] }
             elsif t.thread_variable?(:error)
               errors ||= {}
-              errors[t.thread_variable_get(:node_key)] = t.thread_variable_get(:error)
+              errors[t[:node_key]] = t[:error]
             end
           end
         end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -150,15 +150,15 @@ class RedisClient
         @pipelines&.each_slice(MAX_THREADS) do |chuncked_pipelines|
           threads = chuncked_pipelines.map do |node_key, pipeline|
             Thread.new(node_key, pipeline) do |nk, pl|
-              Thread.current.thread_variable_set(:node_key, nk)
+              Thread.current[:node_key] = nk
               replies = do_pipelining(@router.find_node(nk), pl)
               raise ReplySizeError, "commands: #{pl._size}, replies: #{replies.size}" if pl._size != replies.size
 
-              Thread.current.thread_variable_set(:replies, replies)
+              Thread.current[:replies] = replies
             rescue ::RedisClient::Cluster::Pipeline::RedirectionNeeded => e
-              Thread.current.thread_variable_set(:redirection_needed, e)
+              Thread.current[:redirection_needed] = e
             rescue StandardError => e
-              Thread.current.thread_variable_set(:error, e)
+              Thread.current[:error] = e
             end
           end
 

--- a/test/redis_client/cluster/test_normalized_cmd_name.rb
+++ b/test/redis_client/cluster/test_normalized_cmd_name.rb
@@ -67,15 +67,15 @@ class RedisClient
 
         threads = attempts.each_with_index.map do |_, i|
           Thread.new do
-            Thread.current.thread_variable_set(:index, i)
+            Thread.current[:index] = i
             got = if i.even?
                     @subject.get_by_command(%w[SET foo bar])
                   else
                     @subject.clear ? 'set' : 'clear failed'
                   end
-            Thread.current.thread_variable_set(:got, got)
+            Thread.current[:got] = got
           rescue StandardError => e
-            Thread.current.thread_variable_set(:got, "#{e.class.name}: #{e.message}")
+            Thread.current[:got] = "#{e.class.name}: #{e.message}"
           end
         end
 

--- a/test/redis_client/cluster/test_normalized_cmd_name.rb
+++ b/test/redis_client/cluster/test_normalized_cmd_name.rb
@@ -81,7 +81,7 @@ class RedisClient
 
         threads.each do |t|
           t.join
-          attempts[t.thread_variable_get(:index)] = t.thread_variable_get(:got)
+          attempts[t[:index]] = t[:got]
         end
 
         attempts.each { |got| assert_equal('set', got) }

--- a/test/test_concurrency.rb
+++ b/test/test_concurrency.rb
@@ -56,7 +56,7 @@ class TestConcurrency < TestingWrapper
         ATTEMPTS.times { MAX_THREADS.times { |i| @client.call('INCR', "key#{i}") } }
         ATTEMPTS.times { MAX_THREADS.times { |i| @client.call('DECR', "key#{i}") } }
       rescue StandardError => e
-        Thread.current.thread_variable_set(:error, e)
+        Thread.current[:error] = e
       end
     end
 
@@ -71,7 +71,7 @@ class TestConcurrency < TestingWrapper
         @client.pipelined { |pi| ATTEMPTS.times { MAX_THREADS.times { |i| pi.call('INCR', "key#{i}") } } }
         @client.pipelined { |pi| ATTEMPTS.times { MAX_THREADS.times { |i| pi.call('DECR', "key#{i}") } } }
       rescue StandardError => e
-        Thread.current.thread_variable_set(:error, e)
+        Thread.current[:error] = e
       end
     end
 

--- a/test/test_concurrency.rb
+++ b/test/test_concurrency.rb
@@ -61,7 +61,7 @@ class TestConcurrency < TestingWrapper
     end
 
     threads.each(&:join)
-    threads.each { |t| assert_nil(t.thread_variable_get(:error)) }
+    threads.each { |t| assert_nil(t[:error]) }
     MAX_THREADS.times { |i| assert_equal(WANT, @client.call('GET', "key#{i}")) }
   end
 
@@ -76,7 +76,7 @@ class TestConcurrency < TestingWrapper
     end
 
     threads.each(&:join)
-    threads.each { |t| assert_nil(t.thread_variable_get(:error)) }
+    threads.each { |t| assert_nil(t[:error]) }
     MAX_THREADS.times { |i| assert_equal(WANT, @client.call('GET', "key#{i}")) }
   end
 


### PR DESCRIPTION
```
$ grep thread_variable_get lib/ test/ -rl | xargs sed -i -r -e 's#\.thread_variable_get\((:[_a-z]+)\)#[\1]#g'
$ grep thread_variable_set lib/ test/ -rl | xargs sed -i -r -e 's#\.thread_variable_set\((:[_a-z0-9]+), (.+)\)#[\1] = \2#g'
$ grep thread_variable lib/ test/ -rl | xargs sed -i -e 's#thread_variable#key#g'
```