### PR TITLE
fix: delay transformation of reply data to prevent errors while converting

### DIFF
--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -254,6 +254,16 @@ class RedisClient
           { command: %w[SCRIPT FLUSH], want: 'OK' },
           { command: %w[SCRIPT EXISTS b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c], want: [0] },
           { command: %w[SCRIPT EXISTS 5b9fb3410653a731f8ddfeff39a0c061 31b6de18e43fe980ed07d8b0f5a8cabe], want: [0, 0] },
+          {
+            command: %w[SCRIPT EXISTS b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c],
+            blk: ->(reply) { reply.map { |r| !r.zero? } },
+            want: [false]
+          },
+          {
+            command: %w[SCRIPT EXISTS 5b9fb3410653a731f8ddfeff39a0c061 31b6de18e43fe980ed07d8b0f5a8cabe],
+            blk: ->(reply) { reply.map { |r| !r.zero? } },
+            want: [false, false]
+          },
           { command: %w[PUBSUB CHANNELS test-channel*], want: [] },
           { command: %w[PUBSUB NUMSUB test-channel], want: { 'test-channel' => 0 } },
           { command: %w[PUBSUB NUMPAT], want: 0 },
@@ -264,7 +274,7 @@ class RedisClient
           next if c.key?(:supported_redis_version) && TEST_REDIS_MAJOR_VERSION < c[:supported_redis_version]
 
           msg = "Case: #{c[:command].join(' ')}"
-          got = -> { @client.call(*c[:command]) }
+          got = -> { @client.call_v(c[:command], &c[:blk]) }
           if c.key?(:error)
             assert_raises(c[:error], msg, &got)
           elsif c.key?(:is_a)


### PR DESCRIPTION
Since redis gem's CI is failing:

https://github.com/redis/redis-rb/actions/runs/3931275812/jobs/6722318987

```
  1) Error:
TestClusterCommandsOnScripting#test_script_exists:
TypeError: no implicit conversion of true into Array
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.0/lib/redis_client/cluster/router.rb:270:in `transpose'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.0/lib/redis_client/cluster/router.rb:270:in `send_script_command'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.0/lib/redis_client/cluster/router.rb:50:in `send_command'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.0/lib/redis_client/cluster.rb:30:in `call_v'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:60:in `block in call_v'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:79:in `handle_errors'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:60:in `call_v'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:167:in `block in send_command'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:166:in `synchronize'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:166:in `send_command'
    /home/runner/work/redis-rb/redis-rb/lib/redis/commands/scripting.rb:36:in `script'
    /home/runner/work/redis-rb/redis-rb/cluster/test/commands_on_scripting_test.rb:37:in `test_script_exists'
```