### PR TITLE
fix: a bug for client list command

### DIFF
--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -14,7 +14,7 @@ class RedisClient
     class Router
       ZERO_CURSOR_FOR_SCAN = '0'
       METHODS_FOR_BLOCKING_CMD = %i[blocking_call_v blocking_call].freeze
-      TSF = ->(b, s) { b.nil? ? s : b.call(s) }.curry
+      TSF = ->(f, x) { f.nil? ? x : f.call(x) }.curry
 
       attr_reader :node
 
@@ -240,7 +240,7 @@ class RedisClient
 
       def send_client_command(method, command, args, &block)
         case ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_subcommand(command)
-        when 'list' then @node.call_all(method, command, args).flatten.then(&TSF.call(block))
+        when 'list' then @node.call_all(method, command, args, &block).flatten
         when 'pause', 'reply', 'setname'
           @node.call_all(method, command, args).first.then(&TSF.call(block))
         else assign_node(command).public_send(method, *args, command, &block)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -241,7 +241,11 @@ class RedisClient
           { command: %w[ROLE], is_a: Array },
           { command: %w[CONFIG RESETSTAT], want: 'OK' },
           { command: %w[CONFIG GET maxmemory], is_a: TEST_REDIS_MAJOR_VERSION < 6 ? Array : Hash },
-          { command: %w[CLIENT LIST], is_a: Array },
+          {
+            command: %w[CLIENT LIST],
+            blk: ->(r) { r.lines("\n", chomp: true).map(&:split).map { |e| Hash[e.map { |x| x.split('=') }] } },
+            is_a: Array
+          },
           { command: %w[CLIENT PAUSE 100], want: 'OK' },
           { command: %w[CLIENT INFO], is_a: String, supported_redis_version: 6 },
           { command: %w[CLUSTER SET-CONFIG-EPOCH 0], error: ::RedisClient::Cluster::OrchestrationCommandNotSupported },


### PR DESCRIPTION
This is a enbug by:

* #190

https://github.com/redis/redis-rb/actions/runs/4077433120/jobs/7026449200

```
  1) Error:
TestClusterCommandsOnServer#test_client_list:
NoMethodError: undefined method `lines' for #<Array:0x0000564cb2ac7a38>
    /home/runner/work/redis-rb/redis-rb/lib/redis/commands/server.rb:42:in `block in client'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.1/lib/redis_client/cluster/router.rb:17:in `block in <class:Router>'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.1/lib/redis_client/cluster/router.rb:243:in `then'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.1/lib/redis_client/cluster/router.rb:243:in `send_client_command'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.1/lib/redis_client/cluster/router.rb:42:in `send_command'
    /home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.4.1/lib/redis_client/cluster.rb:30:in `call_v'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:60:in `block in call_v'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:79:in `handle_errors'
    /home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:60:in `call_v'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:167:in `block in send_command'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:166:in `synchronize'
    /home/runner/work/redis-rb/redis-rb/lib/redis.rb:166:in `send_command'
    /home/runner/work/redis-rb/redis-rb/lib/redis/commands/server.rb:40:in `client'
    /home/runner/work/redis-rb/redis-rb/cluster/test/commands_on_server_test.rb:43:in `test_client_list'
```