### PR TITLE
fix: use hostname in node_key if present in CLUSTER NODES

### DIFF
--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -501,6 +501,6 @@ class ClusterController
   def print_debug(msg)
     return unless @debug == '1'
 
-    p msg # rubocop:disable Lint/Debugger
+    p msg
   end
 end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -20,6 +20,7 @@ class RedisClient
       end
     end
 
+    # rubocop:disable Metrics/ClassLength
     class TestNode < TestingWrapper
       def setup
         @test_config = ::RedisClient::ClusterConfig.new(
@@ -173,6 +174,108 @@ class RedisClient
             config_epoch: '6', link_state: 'connected', slots: [] },
           { id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', node_key: '127.0.0.1:30001', role: 'master',
             primary_id: '-', ping_sent: '0', pong_recv: '0', config_epoch: '1', link_state: 'connected', slots: [[0, 3000], [3002, 5460], [15_001, 15_001]] }
+        ]
+
+        got = ::RedisClient::Cluster::Node.send(:parse_cluster_node_reply, info)
+        assert_equal(want, got.map(&:to_h))
+      end
+
+      def test_parse_cluster_node_reply_with_hostname
+        info = <<~INFO
+          07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1:30004@31004,localhost slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 4 connected
+          67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1:30002@31002,localhost master - 0 1426238316232 2 connected 5461-10922
+          292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003,localhost master - 0 1426238318243 3 connected 10923-16383
+          6ec23923021cf3ffec47632106199cb7f496ce01 127.0.0.1:30005@31005,localhost slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 0 1426238316232 5 connected
+          824fe116063bc5fcf9f4ffd895bc17aee7731ac3 127.0.0.1:30006@31006,localhost slave 292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 0 1426238317741 6 connected
+          e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,localhost myself,master - 0 0 1 connected 0-5460
+        INFO
+
+        want = [
+          { id: '07c37dfeb235213a872192d90877d0cd55635b91', node_key: 'localhost:30004', role: 'slave',
+            primary_id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', ping_sent: '0', pong_recv: '1426238317239',
+            config_epoch: '4', link_state: 'connected', slots: [] },
+          { id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', node_key: 'localhost:30002', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '2', link_state: 'connected', slots: [[5461, 10_922]] },
+          { id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', node_key: 'localhost:30003', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238318243',
+            config_epoch: '3', link_state: 'connected', slots: [[10_923, 16_383]] },
+          { id: '6ec23923021cf3ffec47632106199cb7f496ce01', node_key: 'localhost:30005', role: 'slave',
+            primary_id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '5', link_state: 'connected', slots: [] },
+          { id: '824fe116063bc5fcf9f4ffd895bc17aee7731ac3', node_key: 'localhost:30006', role: 'slave',
+            primary_id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', ping_sent: '0', pong_recv: '1426238317741',
+            config_epoch: '6', link_state: 'connected', slots: [] },
+          { id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', node_key: 'localhost:30001', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '0', config_epoch: '1', link_state: 'connected', slots: [[0, 5460]] }
+        ]
+
+        got = ::RedisClient::Cluster::Node.send(:parse_cluster_node_reply, info)
+        assert_equal(want, got.map(&:to_h))
+      end
+
+      def test_parse_cluster_node_reply_with_hostname_and_auxiliaries
+        info = <<~INFO
+          07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1:30004@31004,localhost,shard-id=69bc080733d1355567173199cff4a6a039a2f024 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 4 connected
+          67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1:30002@31002,localhost,shard-id=114f6674a35b84949fe567f5dfd41415ee776261 master - 0 1426238316232 2 connected 5461-10922
+          292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003,localhost,shard-id=fdb36c73e72dd027bc19811b7c219ef6e55c550e master - 0 1426238318243 3 connected 10923-16383
+          6ec23923021cf3ffec47632106199cb7f496ce01 127.0.0.1:30005@31005,localhost,shard-id=114f6674a35b84949fe567f5dfd41415ee776261 slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 0 1426238316232 5 connected
+          824fe116063bc5fcf9f4ffd895bc17aee7731ac3 127.0.0.1:30006@31006,localhost,shard-id=fdb36c73e72dd027bc19811b7c219ef6e55c550e slave 292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 0 1426238317741 6 connected
+          e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,localhost,shard-id=69bc080733d1355567173199cff4a6a039a2f024 myself,master - 0 0 1 connected 0-5460
+        INFO
+
+        want = [
+          { id: '07c37dfeb235213a872192d90877d0cd55635b91', node_key: 'localhost:30004', role: 'slave',
+            primary_id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', ping_sent: '0', pong_recv: '1426238317239',
+            config_epoch: '4', link_state: 'connected', slots: [] },
+          { id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', node_key: 'localhost:30002', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '2', link_state: 'connected', slots: [[5461, 10_922]] },
+          { id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', node_key: 'localhost:30003', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238318243',
+            config_epoch: '3', link_state: 'connected', slots: [[10_923, 16_383]] },
+          { id: '6ec23923021cf3ffec47632106199cb7f496ce01', node_key: 'localhost:30005', role: 'slave',
+            primary_id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '5', link_state: 'connected', slots: [] },
+          { id: '824fe116063bc5fcf9f4ffd895bc17aee7731ac3', node_key: 'localhost:30006', role: 'slave',
+            primary_id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', ping_sent: '0', pong_recv: '1426238317741',
+            config_epoch: '6', link_state: 'connected', slots: [] },
+          { id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', node_key: 'localhost:30001', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '0', config_epoch: '1', link_state: 'connected', slots: [[0, 5460]] }
+        ]
+
+        got = ::RedisClient::Cluster::Node.send(:parse_cluster_node_reply, info)
+        assert_equal(want, got.map(&:to_h))
+      end
+
+      def test_parse_cluster_node_reply_with_auxiliaries
+        info = <<~INFO
+          07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1:30004@31004,,shard-id=69bc080733d1355567173199cff4a6a039a2f024 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 4 connected
+          67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1:30002@31002,,shard-id=114f6674a35b84949fe567f5dfd41415ee776261 master - 0 1426238316232 2 connected 5461-10922
+          292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003,,shard-id=fdb36c73e72dd027bc19811b7c219ef6e55c550e master - 0 1426238318243 3 connected 10923-16383
+          6ec23923021cf3ffec47632106199cb7f496ce01 127.0.0.1:30005@31005,,shard-id=114f6674a35b84949fe567f5dfd41415ee776261 slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 0 1426238316232 5 connected
+          824fe116063bc5fcf9f4ffd895bc17aee7731ac3 127.0.0.1:30006@31006,,shard-id=fdb36c73e72dd027bc19811b7c219ef6e55c550e slave 292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 0 1426238317741 6 connected
+          e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,,shard-id=69bc080733d1355567173199cff4a6a039a2f024 myself,master - 0 0 1 connected 0-5460
+        INFO
+
+        want = [
+          { id: '07c37dfeb235213a872192d90877d0cd55635b91', node_key: '127.0.0.1:30004', role: 'slave',
+            primary_id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', ping_sent: '0', pong_recv: '1426238317239',
+            config_epoch: '4', link_state: 'connected', slots: [] },
+          { id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', node_key: '127.0.0.1:30002', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '2', link_state: 'connected', slots: [[5461, 10_922]] },
+          { id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', node_key: '127.0.0.1:30003', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '1426238318243',
+            config_epoch: '3', link_state: 'connected', slots: [[10_923, 16_383]] },
+          { id: '6ec23923021cf3ffec47632106199cb7f496ce01', node_key: '127.0.0.1:30005', role: 'slave',
+            primary_id: '67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1', ping_sent: '0', pong_recv: '1426238316232',
+            config_epoch: '5', link_state: 'connected', slots: [] },
+          { id: '824fe116063bc5fcf9f4ffd895bc17aee7731ac3', node_key: '127.0.0.1:30006', role: 'slave',
+            primary_id: '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f', ping_sent: '0', pong_recv: '1426238317741',
+            config_epoch: '6', link_state: 'connected', slots: [] },
+          { id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca', node_key: '127.0.0.1:30001', role: 'master',
+            primary_id: '-', ping_sent: '0', pong_recv: '0', config_epoch: '1', link_state: 'connected', slots: [[0, 5460]] }
         ]
 
         got = ::RedisClient::Cluster::Node.send(:parse_cluster_node_reply, info)
@@ -506,5 +609,6 @@ class RedisClient
         end
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -53,7 +53,7 @@ class TestAgainstClusterScale < TestingWrapper
       raise unless e.message.start_with?('CLUSTERDOWN Hash slot not served')
 
       # FIXME: Why does the error occur?
-      p "key#{i}" # rubocop:disable Lint/Debugger
+      p "key#{i}"
     end
 
     want = TEST_NODE_URIS.size


### PR DESCRIPTION
This PR proposes to use `hostname:ip` for the node key instead of `ip:port` if `cluster-preferred-endpoint-type` is set to `hostname` while running a Redis Cluster on Redis v7.0. 

This allows the client to handle redirection responses which uses the preferred endpoint (e.g. `MOVED <slot number> <preferred endpoint>:<port>`) if the cluster is configured to use `hostname`.

Resolves https://github.com/redis-rb/redis-cluster-client/issues/205