### PR TITLE
perf: use early return when loading cluster info

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -116,6 +116,8 @@ class RedisClient
                 errors[t[:index]] = t[:error]
               end
             end
+
+            break unless node_info_list.nil?
           end
 
           raise ::RedisClient::Cluster::InitialSetupError, errors if node_info_list.nil?


### PR DESCRIPTION
This PR adds an early return when loading cluster node information. Instead of checking all 37 sampled nodes that could place unnecessary load during deployments, we use the results on the first successful batch (5 nodes).

Resolves https://github.com/redis-rb/redis-cluster-client/issues/241