### PR TITLE
fix: allow configurable max startup samples

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -15,7 +15,7 @@ class RedisClient
       SLOT_SIZE = 16_384
       MIN_SLOT = 0
       MAX_SLOT = SLOT_SIZE - 1
-      MAX_STARTUP_SAMPLE = 37
+      MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
       MAX_THREADS = Integer(ENV.fetch('REDIS_CLIENT_MAX_THREADS', 5))
       IGNORE_GENERIC_CONFIG_KEYS = %i[url host port path].freeze
       DEAD_FLAGS = %w[fail? fail handshake noaddr noflags].freeze


### PR DESCRIPTION
This PR enables users to configure `MAX_STARTUP_SAMPLE` via the environment variable `REDIS_CLIENT_MAX_STARTUP_SAMPLE`, defaulting to 3 (a pretty reasonable baseline default since the smallest possible cluster size is 3). 

Credits to suggestion in https://github.com/redis-rb/redis-cluster-client/pull/242#issuecomment-1677163041

This PR resolves the spike in initialization load in https://github.com/redis-rb/redis-cluster-client/issues/241 by allowing users to configure a sample size more appropriate for their clusters.

Note/caveat: when it comes to sampling, it is always probabilistic. To combat the risk of under-sampling, users could configure their application to retry on `::RedisClient::Cluster::InitialSetupError` and reload using another sample.