### PR TITLE
feat: add concurrent worker model option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'redis-cluster-client'
 
+gem 'benchmark-ips'
 gem 'hiredis-client', '~> 0.6'
 gem 'memory_profiler'
 gem 'minitest'

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,14 @@ Rake::TestTask.new(:bench) do |t|
   t.test_files = ARGV.size > 1 ? ARGV[1..] : Dir['test/**/bench_*.rb']
 end
 
+Rake::TestTask.new(:ips) do |t|
+  t.libs << :lib
+  t.libs << :test
+  t.options = '-v'
+  t.warning = false
+  t.test_files = ARGV.size > 1 ? ARGV[1..] : Dir['test/**/ips_*.rb']
+end
+
 Rake::TestTask.new(:prof) do |t|
   t.libs << :lib
   t.libs << :test

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -11,9 +11,9 @@ class RedisClient
 
     attr_reader :config
 
-    def initialize(config, pool: nil, **kwargs)
+    def initialize(config, pool: nil, concurrent_worker_model: nil, **kwargs)
       @config = config
-      @concurrent_worker = ::RedisClient::Cluster::ConcurrentWorker.create
+      @concurrent_worker = ::RedisClient::Cluster::ConcurrentWorker.create(model: concurrent_worker_model)
       @router = ::RedisClient::Cluster::Router.new(config, @concurrent_worker, pool: pool, **kwargs)
       @command_builder = config.command_builder
     end

--- a/lib/redis_client/cluster/concurrent_worker.rb
+++ b/lib/redis_client/cluster/concurrent_worker.rb
@@ -64,7 +64,7 @@ class RedisClient
 
       def create(model: :on_demand)
         case model
-        when :on_demand then ::RedisClient::Cluster::ConcurrentWorker::OnDemand.new
+        when :on_demand, nil then ::RedisClient::Cluster::ConcurrentWorker::OnDemand.new
         when :pooled then ::RedisClient::Cluster::ConcurrentWorker::Pooled.new
         else raise ArgumentError, "Unknown model: #{model}"
         end

--- a/test/ips_pipeline.rb
+++ b/test/ips_pipeline.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'redis_cluster_client'
+require 'testing_constants'
+
+module BenchPipeline
+  module_function
+
+  ATTEMPTS = 100
+
+  def run
+    on_demand = make_client(:on_demand)
+    pooled = make_client(:pooled)
+    prepare(on_demand, pooled)
+    bench(on_demand, pooled)
+  end
+
+  def make_client(model)
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      concurrent_worker_model: model,
+      **TEST_GENERIC_OPTIONS
+    ).new_client
+  end
+
+  def prepare(on_demand, pooled)
+    on_demand.pipelined do |pi|
+      ATTEMPTS.times { |i| pi.call('SET', "key#{i}", "val#{i}") }
+    end
+
+    pooled.pipelined do |pi|
+      ATTEMPTS.times { |i| pi.call('SET', "key#{i}", "val#{i}") }
+    end
+  end
+
+  def bench(on_demand, pooled)
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+
+      x.report('on_demand') do
+        on_demand.pipelined { |pi| ATTEMPTS.times { |i| pi.call('GET', "key#{i}") } }
+      end
+
+      x.report('pooled') do
+        pooled.pipelined { |pi| ATTEMPTS.times { |i| pi.call('GET', "key#{i}") } }
+      end
+
+      x.compare!
+    end
+  end
+end
+
+BenchPipeline.run


### PR DESCRIPTION
Not as fast as I thought.

```
$ bundle exec rake ips
Warming up --------------------------------------
           on_demand    29.000  i/100ms
              pooled    32.000  i/100ms
Calculating -------------------------------------
           on_demand    303.783  (± 9.5%) i/s -      1.508k in   5.024205s
              pooled    324.667  (± 3.4%) i/s -      1.632k in   5.032874s

Comparison:
              pooled:      324.7 i/s
           on_demand:      303.8 i/s - same-ish: difference falls within error
```