### PR TITLE
chore: add some benchmarks for iteration per seconds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,6 +195,8 @@ jobs:
         run: df -h
       - name: Run minitest
         run: bundle exec rake bench | grep BenchCommand | grep -v 'Envoy#bench_pipeline_echo\|Envoy#bench_single_echo' | sort
+      - name: Run iteration per second
+        run: bundle exec rake ips
       - name: Reset qdisc
         run: |
           for i in {5..9..2}
@@ -237,33 +239,6 @@ jobs:
         run: bundle exec rake prof
         env:
           MEMORY_PROFILE_MODE: ${{ matrix.mode }}
-      - name: Stop containers
-        run: docker compose -f $DOCKER_COMPOSE_FILE down || true
-  ips:
-    name: IPS
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    env:
-      REDIS_VERSION: '7.2'
-      DOCKER_COMPOSE_FILE: 'compose.yaml'
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-      - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
-      - name: Run containers
-        run: docker compose -f $DOCKER_COMPOSE_FILE up -d
-      - name: Wait for Redis cluster to be ready
-        run: bundle exec rake wait
-      - name: Print containers
-        run: docker compose -f $DOCKER_COMPOSE_FILE ps
-      - name: Run iteration per second
-        run: bundle exec rake ips
       - name: Stop containers
         run: docker compose -f $DOCKER_COMPOSE_FILE down || true
   massive:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       REDIS_CLIENT_MAX_STARTUP_SAMPLE: ${{ matrix.startup || '3' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -80,7 +80,7 @@ jobs:
       DOCKER_COMPOSE_FILE: 'compose.nat.yaml'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -155,7 +155,7 @@ jobs:
       DELAY_TIME: '1ms'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -219,7 +219,7 @@ jobs:
       DOCKER_COMPOSE_FILE: 'compose.yaml'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -239,6 +239,33 @@ jobs:
           MEMORY_PROFILE_MODE: ${{ matrix.mode }}
       - name: Stop containers
         run: docker compose -f $DOCKER_COMPOSE_FILE down || true
+  ips:
+    name: IPS
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      REDIS_VERSION: '7.2'
+      DOCKER_COMPOSE_FILE: 'compose.yaml'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Pull Docker images
+        run: docker pull redis:$REDIS_VERSION
+      - name: Run containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE up -d
+      - name: Wait for Redis cluster to be ready
+        run: bundle exec rake wait
+      - name: Print containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE ps
+      - name: Run iteration per second
+        run: bundle exec rake ips
+      - name: Stop containers
+        run: docker compose -f $DOCKER_COMPOSE_FILE down || true
   massive:
     name: Massive Cluster
     timeout-minutes: 10
@@ -251,7 +278,7 @@ jobs:
       REDIS_CLIENT_MAX_STARTUP_SAMPLE: '5'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/lib/redis_client/cluster/concurrent_worker.rb
+++ b/lib/redis_client/cluster/concurrent_worker.rb
@@ -17,9 +17,16 @@ class RedisClient
         ) do
           def exec
             self[:result] = block&.call(*args, **kwargs)
-            queue&.push(self)
           rescue StandardError => e
             self[:result] = e
+          ensure
+            done
+          end
+
+          def done
+            queue&.push(self)
+          rescue ClosedQueueError
+            # something was wrong
           end
         end
 

--- a/lib/redis_client/cluster/concurrent_worker.rb
+++ b/lib/redis_client/cluster/concurrent_worker.rb
@@ -17,10 +17,9 @@ class RedisClient
         ) do
           def exec
             self[:result] = block&.call(*args, **kwargs)
+            queue&.push(self)
           rescue StandardError => e
             self[:result] = e
-          ensure
-            queue&.push(self)
           end
         end
 
@@ -68,6 +67,10 @@ class RedisClient
         when :pooled then ::RedisClient::Cluster::ConcurrentWorker::Pooled.new
         else raise ArgumentError, "Unknown model: #{model}"
         end
+      end
+
+      def size
+        MAX_WORKERS.positive? ? MAX_WORKERS : 5
       end
     end
   end

--- a/lib/redis_client/cluster/concurrent_worker/on_demand.rb
+++ b/lib/redis_client/cluster/concurrent_worker/on_demand.rb
@@ -5,14 +5,10 @@ class RedisClient
     module ConcurrentWorker
       class OnDemand
         def initialize
-          size = ::RedisClient::Cluster::ConcurrentWorker::MAX_WORKERS
-          size = size.positive? ? size : 5
-          @q = SizedQueue.new(size)
+          @q = SizedQueue.new(::RedisClient::Cluster::ConcurrentWorker.size)
         end
 
         def new_group(size:)
-          raise ArgumentError, "size must be positive: #{size} given" unless size.positive?
-
           ::RedisClient::Cluster::ConcurrentWorker::Group.new(worker: self, size: size)
         end
 

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -60,7 +60,7 @@ class RedisClient
         [
           {
             params: { options: TEST_NODE_OPTIONS, kwargs: TEST_GENERIC_OPTIONS },
-            want: { size: TEST_NODE_OPTIONS.size }
+            want: { size: TEST_NUMBER_OF_NODES }
           },
           {
             params: { options: { '127.0.0.1:11211' => { host: '127.0.0.1', port: 11_211 } }, kwargs: TEST_GENERIC_OPTIONS },


### PR DESCRIPTION
```
################################################################################
# pipelined
################################################################################

Warming up --------------------------------------
 pipelined: ondemand    68.000  i/100ms
   pipelined: pooled    63.000  i/100ms
    pipelined: envoy    41.000  i/100ms
   pipelined: cproxy    49.000  i/100ms
Calculating -------------------------------------
 pipelined: ondemand    690.077  (± 5.4%) i/s -      3.468k in   5.043327s
   pipelined: pooled    716.485  (± 8.7%) i/s -      3.591k in   5.063423s
    pipelined: envoy    411.958  (± 7.5%) i/s -      2.050k in   5.014065s
   pipelined: cproxy    400.665  (±22.7%) i/s -      1.911k in   5.040554s

Comparison:
   pipelined: pooled:      716.5 i/s
 pipelined: ondemand:      690.1 i/s - same-ish: difference falls within error
    pipelined: envoy:      412.0 i/s - 1.74x  slower
   pipelined: cproxy:      400.7 i/s - 1.79x  slower

################################################################################
# single
################################################################################

Warming up --------------------------------------
         single: cli   136.000  i/100ms
       single: envoy    16.000  i/100ms
      single: cproxy    55.000  i/100ms
Calculating -------------------------------------
         single: cli      1.382k (± 9.4%) i/s -      6.936k in   5.077389s
       single: envoy    160.653  (± 5.6%) i/s -    816.000  in   5.100312s
      single: cproxy    557.871  (± 8.1%) i/s -      2.805k in   5.070534s

Comparison:
         single: cli:     1382.1 i/s
      single: cproxy:      557.9 i/s - 2.48x  slower
       single: envoy:      160.7 i/s - 8.60x  slower
```