### PR TITLE
ci: benchmark should be fair

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,14 +195,14 @@ jobs:
         run: df -h
       - name: Run minitest
         run: bundle exec rake bench | grep BenchCommand | grep -v 'Envoy#bench_pipeline_echo\|Envoy#bench_single_echo' | sort
-      - name: Run iteration per second
-        run: bundle exec rake ips
       - name: Reset qdisc
         run: |
           for i in {5..9..2}
           do
             docker compose -f $DOCKER_COMPOSE_FILE exec node$i tc qdisc del dev eth0 root netem || true
           done
+      - name: Run iteration per second
+        run: bundle exec rake ips
       - name: Stop containers
         run: docker compose -f $DOCKER_COMPOSE_FILE down || true
   profiling:

--- a/test/ips_pipeline.rb
+++ b/test/ips_pipeline.rb
@@ -27,6 +27,8 @@ module IpsPipeline
   def make_client(model)
     ::RedisClient.cluster(
       nodes: TEST_NODE_URIS,
+      replica: true,
+      replica_affinity: :random,
       fixed_hostname: TEST_FIXED_HOSTNAME,
       concurrent_worker_model: model,
       **TEST_GENERIC_OPTIONS

--- a/test/ips_single.rb
+++ b/test/ips_single.rb
@@ -25,6 +25,8 @@ module IpsSingle
   def make_client
     ::RedisClient.cluster(
       nodes: TEST_NODE_URIS,
+      replica: true,
+      replica_affinity: :random,
       fixed_hostname: TEST_FIXED_HOSTNAME,
       **TEST_GENERIC_OPTIONS
     ).new_client


### PR DESCRIPTION
# Pipelining performance of Envoy is awesome!

* #266

```
################################################################################
# pipelined
################################################################################

Warming up --------------------------------------
 pipelined: ondemand    47.000  i/100ms
   pipelined: pooled    51.000  i/100ms
    pipelined: envoy    51.000  i/100ms
   pipelined: cproxy    34.000  i/100ms
Calculating -------------------------------------
 pipelined: ondemand    485.444  (± 3.7%) i/s -      2.444k in   5.041748s
   pipelined: pooled    506.902  (±11.4%) i/s -      2.499k in   5.023392s
    pipelined: envoy    509.337  (±11.0%) i/s -      2.550k in   5.079907s
   pipelined: cproxy    406.835  (±16.0%) i/s -      2.006k in   5.081378s

Comparison:
    pipelined: envoy:      509.3 i/s
   pipelined: pooled:      506.9 i/s - same-ish: difference falls within error
 pipelined: ondemand:      485.4 i/s - same-ish: difference falls within error
   pipelined: cproxy:      406.8 i/s - same-ish: difference falls within error

################################################################################
# single
################################################################################

Warming up --------------------------------------
         single: cli   103.000  i/100ms
       single: envoy    32.000  i/100ms
      single: cproxy    48.000  i/100ms
Calculating -------------------------------------
         single: cli      1.138k (± 6.5%) i/s -      5.665k in   5.001364s
       single: envoy    322.871  (± 8.4%) i/s -      1.600k in   5.004549s
      single: cproxy    473.707  (±11.6%) i/s -      2.352k in   5.049529s

Comparison:
         single: cli:     1138.3 i/s
      single: cproxy:      473.7 i/s - 2.40x  slower
       single: envoy:      322.9 i/s - 3.53x  slower
```

There is room for improvement in our client.