### PR TITLE
fix: rename option for concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ gem 'redis-cluster-client'
 | `:replica` | Boolean | `false` | `true` if client should use scale read feature |
 | `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random`, `random_with_primary` or `:latency` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
+| `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
 But `:url`, `:host`, `:port` and `:path` are ignored because they conflict with the `:nodes` option.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gem 'redis-cluster-client'
 | `:replica` | Boolean | `false` | `true` if client should use scale read feature |
 | `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random`, `random_with_primary` or `:latency` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
-| `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency |
+| `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
 But `:url`, `:host`, `:port` and `:path` are ignored because they conflict with the `:nodes` option.

--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -11,9 +11,9 @@ class RedisClient
 
     attr_reader :config
 
-    def initialize(config, pool: nil, concurrent_worker_model: nil, **kwargs)
+    def initialize(config, pool: nil, concurrency: nil, **kwargs)
       @config = config
-      @concurrent_worker = ::RedisClient::Cluster::ConcurrentWorker.create(model: concurrent_worker_model)
+      @concurrent_worker = ::RedisClient::Cluster::ConcurrentWorker.create(**(concurrency || {}))
       @router = ::RedisClient::Cluster::Router.new(config, @concurrent_worker, pool: pool, **kwargs)
       @command_builder = config.command_builder
     end

--- a/lib/redis_client/cluster/concurrent_worker/none.rb
+++ b/lib/redis_client/cluster/concurrent_worker/none.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    module ConcurrentWorker
+      class None
+        def new_group(size:)
+          ::RedisClient::Cluster::ConcurrentWorker::Group.new(
+            worker: self,
+            queue: Array.new(size),
+            size: size
+          )
+        end
+
+        def push(task)
+          task.exec
+        end
+
+        def close; end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/concurrent_worker/on_demand.rb
+++ b/lib/redis_client/cluster/concurrent_worker/on_demand.rb
@@ -4,12 +4,16 @@ class RedisClient
   class Cluster
     module ConcurrentWorker
       class OnDemand
-        def initialize
-          @q = SizedQueue.new(::RedisClient::Cluster::ConcurrentWorker.size)
+        def initialize(size:)
+          @q = SizedQueue.new(size)
         end
 
         def new_group(size:)
-          ::RedisClient::Cluster::ConcurrentWorker::Group.new(worker: self, size: size)
+          ::RedisClient::Cluster::ConcurrentWorker::Group.new(
+            worker: self,
+            queue: SizedQueue.new(size),
+            size: size
+          )
         end
 
         def push(task)

--- a/test/ips_pipeline.rb
+++ b/test/ips_pipeline.rb
@@ -12,13 +12,15 @@ module IpsPipeline
   def run
     on_demand = make_client(:on_demand)
     pooled = make_client(:pooled)
+    none = make_client(:none)
     envoy = make_client_for_envoy
     cluster_proxy = make_client_for_cluster_proxy
-    prepare(on_demand, pooled, envoy, cluster_proxy)
+    prepare(on_demand, pooled, none, envoy, cluster_proxy)
     print_letter('pipelined')
     bench(
       ondemand: on_demand,
       pooled: pooled,
+      none: none,
       envoy: envoy,
       cproxy: cluster_proxy
     )
@@ -30,7 +32,7 @@ module IpsPipeline
       replica: true,
       replica_affinity: :random,
       fixed_hostname: TEST_FIXED_HOSTNAME,
-      concurrent_worker_model: model,
+      concurrency: { model: model },
       **TEST_GENERIC_OPTIONS
     ).new_client
   end

--- a/test/redis_client/cluster/concurrent_worker/test_none.rb
+++ b/test/redis_client/cluster/concurrent_worker/test_none.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'testing_helper'
+require 'redis_client/cluster/concurrent_worker/mixin'
+
+class RedisClient
+  class Cluster
+    module ConcurrentWorker
+      class TestNone < TestingWrapper
+        include Mixin
+
+        private
+
+        def model
+          :none
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Oh my gosh

```
################################################################################
# pipelined
################################################################################

Warming up --------------------------------------
 pipelined: ondemand    46.000  i/100ms
   pipelined: pooled    52.000  i/100ms
     pipelined: none    49.000  i/100ms
    pipelined: envoy    46.000  i/100ms
   pipelined: cproxy    39.000  i/100ms
Calculating -------------------------------------
 pipelined: ondemand    463.272  (± 8.0%) i/s -      2.300k in   5.011685s
   pipelined: pooled    505.496  (± 8.1%) i/s -      2.548k in   5.094204s
     pipelined: none    489.561  (± 9.6%) i/s -      2.450k in   5.072220s
    pipelined: envoy    516.512  (±11.4%) i/s -      2.576k in   5.080221s
   pipelined: cproxy    414.037  (±13.5%) i/s -      2.067k in   5.109599s

Comparison:
    pipelined: envoy:      516.5 i/s
   pipelined: pooled:      505.5 i/s - same-ish: difference falls within error
     pipelined: none:      489.6 i/s - same-ish: difference falls within error
 pipelined: ondemand:      463.3 i/s - same-ish: difference falls within error
   pipelined: cproxy:      414.0 i/s - same-ish: difference falls within error

################################################################################
# single
################################################################################

Warming up --------------------------------------
         single: cli    74.000  i/100ms
       single: envoy    32.000  i/100ms
      single: cproxy    44.000  i/100ms
Calculating -------------------------------------
         single: cli      1.145k (± 7.7%) i/s -      5.698k in   5.030021s
       single: envoy    324.815  (± 6.5%) i/s -      1.632k in   5.053793s
      single: cproxy    457.558  (±10.9%) i/s -      2.288k in   5.080246s

Comparison:
         single: cli:     1144.5 i/s
      single: cproxy:      457.6 i/s - 2.50x  slower
       single: envoy:      324.8 i/s - 3.52x  slower
```