### PR TITLE
perf: add an environment variable to be able to configure a data type of slots and nodes mapping

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -17,7 +17,7 @@ class RedisClient
       MIN_SLOT = 0
       MAX_SLOT = SLOT_SIZE - 1
       MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
-      USE_CHAR_ARRAY_SLOT = Integer(ENV.fetch('REDIS_CLIENT_USE_CHAR_ARRAY_SLOT', 0)) == 1 # less memory consumption, but too slow
+      USE_CHAR_ARRAY_SLOT = Integer(ENV.fetch('REDIS_CLIENT_USE_CHAR_ARRAY_SLOT', 1)) == 1 # less memory consumption, but slow
       IGNORE_GENERIC_CONFIG_KEYS = %i[url host port path].freeze
       DEAD_FLAGS = %w[fail? fail handshake noaddr noflags].freeze
       ROLE_FLAGS = %w[master slave].freeze

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -17,6 +17,7 @@ class RedisClient
       MIN_SLOT = 0
       MAX_SLOT = SLOT_SIZE - 1
       MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
+      USE_CHAR_ARRAY_SLOT = Integer(ENV.fetch('REDIS_CLIENT_USE_CHAR_ARRAY_SLOT', 0)) == 1 # less memory consumption, but too slow
       IGNORE_GENERIC_CONFIG_KEYS = %i[url host port path].freeze
       DEAD_FLAGS = %w[fail? fail handshake noaddr noflags].freeze
       ROLE_FLAGS = %w[master slave].freeze
@@ -310,7 +311,7 @@ class RedisClient
       end
 
       def make_array_for_slot_node_mappings(node_info_list)
-        return Array.new(SLOT_SIZE) if node_info_list.count(&:primary?) > 256
+        return Array.new(SLOT_SIZE) if !USE_CHAR_ARRAY_SLOT || node_info_list.count(&:primary?) > 256
 
         primary_node_keys = node_info_list.select(&:primary?).map(&:node_key)
         ::RedisClient::Cluster::Node::CharArray.new(SLOT_SIZE, primary_node_keys)

--- a/test/ips_slot_array.rb
+++ b/test/ips_slot_array.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'redis_cluster_client'
+
+module IpsSlotArray
+  ELEMENTS = %w[foo bar baz].freeze
+  SIZE = 256
+
+  module_function
+
+  def run
+    ca = ::RedisClient::Cluster::Node::CharArray.new(::RedisClient::Cluster::Node::SLOT_SIZE, ELEMENTS)
+    arr = Array.new(::RedisClient::Cluster::Node::SLOT_SIZE)
+
+    print_letter('CharArray vs Array')
+    fullfill(ca)
+    fullfill(arr)
+    bench({ ca.class.name.split('::').last => ca, arr.class.name => arr })
+  end
+
+  def make_worker(model)
+    ::RedisClient::Cluster::ConcurrentWorker.create(model: model, size: WORKER_SIZE)
+  end
+
+  def print_letter(title)
+    print "################################################################################\n"
+    print "# #{title}\n"
+    print "################################################################################\n"
+    print "\n"
+  end
+
+  def fullfill(arr)
+    SIZE.times { |i| arr[i] = ELEMENTS[i % ELEMENTS.size] }
+  end
+
+  def bench(subjects)
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+
+      subjects.each do |subtitle, arr|
+        x.report(subtitle) do
+          arr[0] = arr[1]
+        end
+      end
+
+      x.compare!
+    end
+  end
+end
+
+IpsSlotArray.run

--- a/test/ips_slot_node_mapping.rb
+++ b/test/ips_slot_node_mapping.rb
@@ -3,24 +3,20 @@
 require 'benchmark/ips'
 require 'redis_cluster_client'
 
-module IpsSlotArray
+module IpsSlotNodeMapping
   ELEMENTS = %w[foo bar baz].freeze
-  SIZE = 256
+  SIZE = ::RedisClient::Cluster::Node::SLOT_SIZE
 
   module_function
 
   def run
-    ca = ::RedisClient::Cluster::Node::CharArray.new(::RedisClient::Cluster::Node::SLOT_SIZE, ELEMENTS)
-    arr = Array.new(::RedisClient::Cluster::Node::SLOT_SIZE)
+    ca = ::RedisClient::Cluster::Node::CharArray.new(SIZE, ELEMENTS)
+    arr = Array.new(SIZE)
 
-    print_letter('CharArray vs Array')
+    print_letter('Mappings between slots and nodes')
     fullfill(ca)
     fullfill(arr)
     bench({ ca.class.name.split('::').last => ca, arr.class.name => arr })
-  end
-
-  def make_worker(model)
-    ::RedisClient::Cluster::ConcurrentWorker.create(model: model, size: WORKER_SIZE)
   end
 
   def print_letter(title)
@@ -41,7 +37,7 @@ module IpsSlotArray
 
       subjects.each do |subtitle, arr|
         x.report(subtitle) do
-          arr[0] = arr[1]
+          arr[0]
         end
       end
 
@@ -50,4 +46,4 @@ module IpsSlotArray
   end
 end
 
-IpsSlotArray.run
+IpsSlotNodeMapping.run

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -488,7 +488,7 @@ class RedisClient
 
         want = node_info_list.first.node_key
         got = @test_node.send(:make_array_for_slot_node_mappings, node_info_list)
-        assert_instance_of(::RedisClient::Cluster::Node::CharArray, got)
+        assert_instance_of(::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT ? ::RedisClient::Cluster::Node::CharArray : Array, got)
         ::RedisClient::Cluster::Node::SLOT_SIZE.times do |i|
           got[i] = want
           assert_equal(want, got[i], "Case: #{i}")
@@ -521,19 +521,19 @@ class RedisClient
         end
 
         got = @test_node.send(:make_array_for_slot_node_mappings, node_info_list)
-        assert_instance_of(::RedisClient::Cluster::Node::CharArray, got)
+        assert_instance_of(::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT ? ::RedisClient::Cluster::Node::CharArray : Array, got)
 
         ::RedisClient::Cluster::Node::SLOT_SIZE.times { |i| got[i] = node_info_list.first.node_key }
 
         got[0] = 'newbie:6379'
         assert_equal('newbie:6379', got[0])
-        assert_raises(RangeError) { got[0] = 'zombie:6379' }
+        assert_raises(RangeError) { got[0] = 'zombie:6379' } if ::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT
 
-        assert_raises(IndexError) { got[-1] = 'newbie:6379' }
-        assert_raises(IndexError) { got[-1] }
+        assert_raises(IndexError) { got[-1] = 'newbie:6379' } if ::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT
+        assert_raises(IndexError) { got[-1] } if ::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT
 
         got[16_384] = 'newbie:6379'
-        assert_nil(got[16_384])
+        assert_nil(got[16_384]) if ::RedisClient::Cluster::Node::USE_CHAR_ARRAY_SLOT
       end
 
       def test_build_replication_mappings_regular


### PR DESCRIPTION
## Iteration per second
### VS
```
################################################################################
# Mappings between slots and nodes
################################################################################

Warming up --------------------------------------
           CharArray   783.598k i/100ms
               Array     1.849M i/100ms
Calculating -------------------------------------
           CharArray      7.804M (± 2.4%) i/s -     39.180M in   5.024004s
               Array     18.948M (± 3.8%) i/s -     96.166M in   5.083967s

Comparison:
               Array: 18947756.4 i/s
           CharArray:  7803935.6 i/s - 2.43x  slower
```

### Array
```
################################################################################
# pipelined
################################################################################

Warming up --------------------------------------
 pipelined: ondemand    50.000  i/100ms
   pipelined: pooled    53.000  i/100ms
     pipelined: none    53.000  i/100ms
    pipelined: envoy    55.000  i/100ms
   pipelined: cproxy    47.000  i/100ms
Calculating -------------------------------------
 pipelined: ondemand    483.238  (±10.1%) i/s -      2.400k in   5.030776s
   pipelined: pooled    529.960  (± 8.9%) i/s -      2.650k in   5.054174s
     pipelined: none    519.811  (± 6.7%) i/s -      2.650k in   5.125332s
    pipelined: envoy    553.978  (± 6.9%) i/s -      2.805k in   5.095757s
   pipelined: cproxy    366.108  (±21.0%) i/s -      1.786k in   5.136825s

Comparison:
    pipelined: envoy:      554.0 i/s
   pipelined: pooled:      530.0 i/s - same-ish: difference falls within error
     pipelined: none:      519.8 i/s - same-ish: difference falls within error
 pipelined: ondemand:      483.2 i/s - same-ish: difference falls within error
   pipelined: cproxy:      366.1 i/s - 1.51x  slower
```

### CharArray
```
################################################################################
# pipelined
################################################################################

Warming up --------------------------------------
 pipelined: ondemand    41.000  i/100ms
   pipelined: pooled    60.000  i/100ms
     pipelined: none    61.000  i/100ms
    pipelined: envoy    63.000  i/100ms
   pipelined: cproxy    40.000  i/100ms
Calculating -------------------------------------
 pipelined: ondemand    561.485  (± 8.9%) i/s -      2.788k in   5.020871s
   pipelined: pooled    608.369  (± 8.1%) i/s -      3.060k in   5.077427s
     pipelined: none    622.878  (± 1.6%) i/s -      3.172k in   5.093801s
    pipelined: envoy    628.646  (± 9.5%) i/s -      3.150k in   5.074765s
   pipelined: cproxy    490.748  (±13.7%) i/s -      2.400k in   5.047291s

Comparison:
    pipelined: envoy:      628.6 i/s
     pipelined: none:      622.9 i/s - same-ish: difference falls within error
   pipelined: pooled:      608.4 i/s - same-ish: difference falls within error
 pipelined: ondemand:      561.5 i/s - same-ish: difference falls within error
   pipelined: cproxy:      490.7 i/s - 1.28x  slower
```

It seems that the bottleneck is another location. Envoy tops us in pipelining.

## Memory profiling
### Array
```
################################################################################
# pipelining_in_moderation: primary_only
################################################################################

Total allocated: 2711216 bytes (45335 objects)
Total retained:  120 bytes (3 objects)

allocated memory by gem
-----------------------------------
   1867194  redis-client-0.17.0
    563283  redis-cluster-client/lib
    172280  other
     96987  socket
     11472  uri

allocated memory by file
-----------------------------------
    799044  redis-client-0.17.0/lib/redis_client/ruby_connection/resp3.rb
    760182  redis-client-0.17.0/lib/redis_client/ruby_connection/buffered_io.rb
    313579  redis-cluster-client/lib/redis_client/cluster/node.rb
    280160  redis-client-0.17.0/lib/redis_client/command_builder.rb
    169640  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
```

### CharArray
```
################################################################################
# pipelining_in_moderation: primary_only
################################################################################

Total allocated: 2462301 bytes (45341 objects)
Total retained:  120 bytes (3 objects)

allocated memory by gem
-----------------------------------
   1867194  redis-client-0.17.0
    335053  redis-cluster-client/lib
    172280  other
     76302  socket
     11472  uri

allocated memory by file
-----------------------------------
    799044  redis-client-0.17.0/lib/redis_client/ruby_connection/resp3.rb
    760182  redis-client-0.17.0/lib/redis_client/ruby_connection/buffered_io.rb
    280160  redis-client-0.17.0/lib/redis_client/command_builder.rb
    169640  /home/runner/work/redis-cluster-client/redis-cluster-client/test/prof_mem.rb
     85541  redis-cluster-client/lib/redis_client/cluster/node.rb
```