### PR TITLE
perf: reduce load of servers in initialization as possible

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -16,7 +16,7 @@ class RedisClient
       # It affects to strike a balance between load and stability in initialization or changed states.
       MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
 
-      #  It's used with slow queries of fetching meta data like CLUSTER NODES, COMMAND and so on.
+      # It's used with slow queries of fetching meta data like CLUSTER NODES, COMMAND and so on.
       SLOW_COMMAND_TIMEOUT = Float(ENV.fetch('REDIS_CLIENT_SLOW_COMMAND_TIMEOUT', -1))
 
       # less memory consumption, but slow

--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'redis_client'
+require 'redis_client/cluster/normalized_cmd_name'
 
 class RedisClient
   class Cluster

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -22,7 +22,7 @@ class RedisClient
         @pool = pool
         @client_kwargs = kwargs
         @node = fetch_cluster_info(@config, @concurrent_worker, pool: @pool, **@client_kwargs)
-        @command = ::RedisClient::Cluster::Command.load(@node.shuffled_nodes)
+        @command = ::RedisClient::Cluster::Command.load(@node.replica_clients.shuffle)
         @mutex = Mutex.new
         @command_builder = @config.command_builder
       end


### PR DESCRIPTION
* This PR relates to:
  * #286
* Add `REDIS_CLIENT_SLOW_COMMAND_TIMEOUT` to environment variables
  * It's used with calling `CLUSTER NODES` and `COMMAND` if specified.
* Use replicas instead of primaries when sending `COMMAND` command
  * But it depends on the topology.