### PR TITLE
Adds new configuration option to specify reconnecting using the original configuration options when refreshing nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ gem 'redis-cluster-client'
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
 | `:slow_command_timeout` | Integer | `-1` | timeout used for "slow" queries that fetch metdata e.g. CLUSTER NODES, COMMAND |
 | `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
+| `:connect_with_original_config` | Boolean | `false` | `true` if client should retry the connection using the original endpoint that was passed in |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
 But `:url`, `:host`, `:port` and `:path` are ignored because they conflict with the `:nodes` option.
@@ -104,6 +105,11 @@ RedisClient.cluster(concurrency: { model: :none }).new_client
 
 # The above settings are used by sending commands to multiple nodes like pipelining.
 # Please choose the one suited your workloads.
+```
+
+```ruby
+# To reconnect using the original configuration options on error. This can be useful when using a DNS endpoint and the underlying host IPs are all updated
+RedisClient.cluster(connect_with_original_config: true).new_client
 ```
 
 ## Interfaces

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -18,6 +18,8 @@ class RedisClient
 
       def initialize(config, concurrent_worker, pool: nil, **kwargs)
         @config = config.dup
+        @original_config = config.dup if config.connect_with_original_config
+        @connect_with_original_config = config.connect_with_original_config
         @concurrent_worker = concurrent_worker
         @pool = pool
         @client_kwargs = kwargs
@@ -329,6 +331,7 @@ class RedisClient
             # ignore
           end
 
+          @config = @original_config.dup if @connect_with_original_config
           @node = fetch_cluster_info(@config, @concurrent_worker, pool: @pool, **@client_kwargs)
         end
       end

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -23,14 +23,15 @@ class RedisClient
 
     InvalidClientConfigError = Class.new(::RedisClient::Error)
 
-    attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout
+    attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout, :connect_with_original_config
 
-    def initialize(
+    def initialize( # rubocop:disable Metrics/AbcSize
       nodes: DEFAULT_NODES,
       replica: false,
       replica_affinity: :random,
       fixed_hostname: '',
       concurrency: nil,
+      connect_with_original_config: false,
       client_implementation: ::RedisClient::Cluster, # for redis gem
       slow_command_timeout: SLOW_COMMAND_TIMEOUT,
       **client_config
@@ -44,6 +45,7 @@ class RedisClient
       @command_builder = client_config.fetch(:command_builder, ::RedisClient::CommandBuilder)
       @client_config = merge_generic_config(client_config, @node_configs)
       @concurrency = merge_concurrency_option(concurrency)
+      @connect_with_original_config = connect_with_original_config
       @client_implementation = client_implementation
       @slow_command_timeout = slow_command_timeout
       @mutex = Mutex.new
@@ -56,6 +58,7 @@ class RedisClient
         replica_affinity: @replica_affinity,
         fixed_hostname: @fixed_hostname,
         concurrency: @concurrency,
+        connect_with_original_config: @connect_with_original_config,
         client_implementation: @client_implementation,
         slow_command_timeout: @slow_command_timeout,
         **@client_config


### PR DESCRIPTION
### Problem
When using a DNS endpoint and all of the underlying host IPs are changed, this can cause continuous connection errors, as the node list is fetched during initialization and then not refreshed from the original DNS endpoint. We've had this happen during Elasticache maintenance when all underlying nodes in the clusters are slowly replaced.

This adds a new configuration option that allows the original configuration that was used for cluster discovery to be used when we receive and error and refresh the node list. We've had a patch that does something similar to this in our current version of redis-rb (4.8) but we're working on migrating to 5.x and would like to upstream this if possible.

I was able to run the tests locally and everything is passing but it was unclear to me how exactly to test this so would appreciate any suggestions around that.

Looking forward to getting any opinions/feedback on this change. Thanks.
