### PR TITLE
Make SLOW_COMMAND_TIMEOUT a configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ gem 'redis-cluster-client'
 | `:replica` | Boolean | `false` | `true` if client should use scale read feature |
 | `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random`, `random_with_primary` or `:latency` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
+| `:slow_command_timeout` | Integer | `-1` | timeout used for "slow" queries that fetch metdata e.g. CLUSTER NODES, COMMAND |
 | `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
@@ -88,6 +89,11 @@ RedisClient.cluster(nodes: 'rediss://endpoint.example.com:6379').new_client
 ```ruby
 # To connect to NAT-ted endpoint with SSL/TLS (such as Microsoft Azure Cache for Redis)
 RedisClient.cluster(nodes: 'rediss://endpoint.example.com:6379', fixed_hostname: 'endpoint.example.com').new_client
+```
+
+```ruby
+# To specify a timeout for "slow" commands (CLUSTER NODES, COMMAND)
+RedisClient.cluster(slow_command_timeout: 4).new_client
 ```
 
 ```ruby

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -7,8 +7,6 @@ require 'redis_client/cluster/normalized_cmd_name'
 class RedisClient
   class Cluster
     class Command
-      SLOW_COMMAND_TIMEOUT = Float(ENV.fetch('REDIS_CLIENT_SLOW_COMMAND_TIMEOUT', -1))
-
       EMPTY_STRING = ''
       LEFT_BRACKET = '{'
       RIGHT_BRACKET = '}'
@@ -23,12 +21,12 @@ class RedisClient
       )
 
       class << self
-        def load(nodes)
+        def load(nodes, slow_command_timeout: -1)
           cmd = errors = nil
 
           nodes&.each do |node|
             regular_timeout = node.read_timeout
-            node.read_timeout = SLOW_COMMAND_TIMEOUT > 0.0 ? SLOW_COMMAND_TIMEOUT : regular_timeout
+            node.read_timeout = slow_command_timeout > 0.0 ? slow_command_timeout : regular_timeout
             reply = node.call('COMMAND')
             node.read_timeout = regular_timeout
             commands = parse_command_reply(reply)

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -22,7 +22,7 @@ class RedisClient
         @pool = pool
         @client_kwargs = kwargs
         @node = fetch_cluster_info(@config, @concurrent_worker, pool: @pool, **@client_kwargs)
-        @command = ::RedisClient::Cluster::Command.load(@node.replica_clients.shuffle)
+        @command = ::RedisClient::Cluster::Command.load(@node.replica_clients.shuffle, slow_command_timeout: config.slow_command_timeout)
         @mutex = Mutex.new
         @command_builder = @config.command_builder
       end
@@ -305,7 +305,7 @@ class RedisClient
       end
 
       def fetch_cluster_info(config, concurrent_worker, pool: nil, **kwargs)
-        node_info_list = ::RedisClient::Cluster::Node.load_info(config.per_node_key, concurrent_worker, **kwargs)
+        node_info_list = ::RedisClient::Cluster::Node.load_info(config.per_node_key, concurrent_worker, slow_command_timeout: config.slow_command_timeout, **kwargs)
         node_addrs = node_info_list.map { |i| ::RedisClient::Cluster::NodeKey.hashify(i.node_key) }
         config.update_node(node_addrs)
         ::RedisClient::Cluster::Node.new(


### PR DESCRIPTION
Thank you so much for your work on https://github.com/redis-rb/redis-cluster-client/issues/286 which addressed adding an override for `slow` commands.

This builds upon that and adds a configuration option for this timeout that can be passed directly to the client. This will allow the option to be contained within the client configuration and remove the need to specify any environment variables outside of said configuration.
