### PR TITLE
Fix MULTI transactions calling the block twice

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Metrics/ClassLength:
 
 Metrics/ModuleLength:
   Max: 500
+  Exclude:
+    - 'test/**/*'
 
 Metrics/MethodLength:
   Max: 50

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -32,10 +32,12 @@ class RedisClient
       alias call_once_v call_v
 
       def execute(watch: nil, &block)
-        if watch&.any?
-          execute_with_watch(watch: watch, &block)
-        else
-          execute_without_watch(&block)
+        @router.force_primary do
+          if watch&.any?
+            execute_with_watch(watch: watch, &block)
+          else
+            execute_without_watch(&block)
+          end
         end
       end
 

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -11,45 +11,81 @@ class RedisClient
         @router = router
         @command_builder = command_builder
         @node_key = nil
+        @node = nil
+        @transaction_commands = []
       end
 
       def call(*command, **kwargs, &_)
         command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
+        ensure_node(command)
+        @transaction_commands << command
+        nil
       end
 
       def call_v(command, &_)
         command = @command_builder.generate(command)
-        ensure_node_key(command)
+        ensure_node(command)
+        @transaction_commands << command
+        nil
       end
-
-      def call_once(*command, **kwargs, &_)
-        command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
-      end
-
-      def call_once_v(command, &_)
-        command = @command_builder.generate(command)
-        ensure_node_key(command)
-      end
+      alias call_once call
+      alias call_once_v call_v
 
       def execute(watch: nil, &block)
-        yield self
-        raise ArgumentError, 'empty transaction' if @node_key.nil?
-
-        node = @router.find_node(@node_key)
-        @router.try_delegate(node, :multi, watch: watch, &block)
+        if watch&.any?
+          execute_with_watch(watch: watch, &block)
+        else
+          execute_without_watch(&block)
+        end
       end
 
       private
 
-      def ensure_node_key(command)
+      def execute_with_watch(watch:)
+        # Validate that all keys to be watched are on the same node
+        watch.each { |key| ensure_node(['WATCH', key]) }
+        # n.b - wrapping this in #try_delegate means we retry the whole transaction on failure, and also
+        # get the recover of e.g. detecting moved slots.
+        @router.try_delegate(@node, :with) do |conn|
+          commit_result = nil
+          @router.try_send(conn, :call_once_v, ['WATCH', *watch], [], retry_count: 0)
+          begin
+            yield self
+            commit_result = @router.try_delegate(conn, :multi, retry_count: 0) do |m|
+              @transaction_commands.each do |cmd|
+                m.call_once_v(cmd)
+              end
+            end
+          ensure
+            # unwatch, except if we committed (it's unnescessary) or the connection is broken anyway (it won't work)
+            @router.try_send(conn, :call_once_v, ['UNWATCH'], [], retry_count: 0) unless commit_result&.any? || !conn.connected?
+          end
+        end
+      end
+
+      def execute_without_watch
+        # We don't know what node is going to be executed on yet.
+        yield self
+        return [] if @node.nil?
+
+        # Now we know. Accumulate the collected commands and send them to the right connection.
+        @router.try_delegate(@node, :multi) do |m|
+          @transaction_commands.each do |cmd|
+            m.call_v(cmd)
+          end
+        end
+      end
+
+      def ensure_node(command)
         node_key = @router.find_primary_node_key(command)
         raise ConsistencyError, "Client couldn't determine the node to be executed the transaction by: #{command}" if node_key.nil?
 
-        @node_key ||= node_key
-        raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
-
+        if @node.nil?
+          @node = @router.find_node(node_key)
+          @node_key = node_key
+        elsif @node_key != node_key
+          raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
+        end
         nil
       end
     end


### PR DESCRIPTION
## What this PR does

Currently using a transaction with `RedisClient::Cluster#multi` actually calls the provided block twice: Once in `RedisClient::Cluster::Transaction#execute` to work out what node to send the transaction to, and then once again in `RedisClient#multi` to actually execute the thing. Also, the first time the block is called, the keys are not watched yet, so any get calls you make in there are stale.

This PR fixes the issue by building up a buffer of transaction commands to execute when yielding the block passed to `#multi`, and then yielding that buffer into `RedisClient#multi` instead of the user-provided block again. That way, the block only gets called once.

This PR also adds in some machinery to make sure that any commands run on the client during a `#multi` block happen on the primary; this is almost always what you want to be doing inside a transaction. If you watch a key on a primary but then read it from the replica, it's possible for you to read a stale value that was already known to the primary when you called `WATCH`; you will then build up a transaction from stale data and your `EXEC` will succeed where you would expect it to fail.

With this PR, it's possible to do e.g. an atomic swap of two variables with something like this:

```ruby
$redis = RedisClient::Cluster.new
$redis.with(watch: ['{hash}key1', {hash}key2']) do |txn|
    old_value_1 = $redis.call_v(['GET', '{hash}key1'])
    old_value_2 = $redis.call_v(['GET', '{hash}key2'])
    txn.call_v(['SET', '{hash}key1', old_value_2])
    txn.call_v(['SET', '{hash}key2', old_value_1])
end
```

Note, though, that it's not possible to actually pass `watch:` keys to `multi` if you're using `redis-cluster-client` through the `redis-rb` and `redis-clustering` gems. That should be a very simple fix however: https://github.com/redis/redis-rb/pull/1236

## What this PR doesn't do

Even with this change, using `Redis::Cluster#multi` from `redis-clustering`/`redis-rb` is pretty wonky. Something like this _does_ work and swap the keys:

```ruby
$redis = Redis::Cluster.new
$redis.set('{hash}key1', 'value1')
$redis.set('{hash}key2', 'value2')

$redis.watch(['{hash}key1', '{hash}key2']) do
  orig_key1 = $redis.get '{hash}key1'
  orig_key2 = $redis.get '{hash}key2'
  $redis.multi do |txn|
    txn.set '{hash}key1', orig_key2
    txn.set '{hash}key2', orig_key1
  end
end
```

But, support for unwatching and _not_ committing the transaction is broken. This throws `RedisClient::Cluster::AmbiguousNodeError` because the router doesn't know what node to send `UNWATCH` to.

```ruby
$redis = Redis::Cluster.new
$redis.set('{hash}key1', 'value1')
$redis.set('{hash}key2', 'value2')

$redis.watch(['{hash}key1', '{hash}key2']) do
  orig_key1 = $redis.get '{hash}key1'
  orig_key2 = $redis.get '{hash}key2'
  # whelp, we didn't like what we read from our gets.
  $redis.unwatch
end
```

This happens because there's nothing storing the idea that a transaction is happening around the entire `watch` block; the `Redis::Cluster::Transaction` is only created around a call to `#multi`. On a similar note, nothing stops you from watching or getting keys from multiple different hash slots in your transaction. For example, this will work, but shouldn't.

```ruby
$redis = Redis::Cluster.new
$redis.set('{hash1}key1', 'value1')
$redis.set('{hash2}key2', 'value2')
$redis.watch(['{hash1}key1']) do
  $redis.watch '{hash2}key2'
  orig_key1 = $redis.get '{hash1}key1'
  orig_key2 = $redis.get '{hash2}key2'

  # some other process changes the value of key2 after we read it
  Thread.new { Redis::Cluster.new.set('{hash2}key2', 'hahahaha') }.join

  # This will commit, but shouldn't, because we're not _really_ watching key2; it's on another node
  # to the one with the transaction
  $redis.multi do |txn|
    txn.set '{hash}key1', orig_key1 + orig_key2
  end
end
```

I played around for a couple of days trying to work out the right way to fix this, but didn't really land on anything I like. I'm open to ideas if you can think of any good way to do this though. The closest I came up with was [this](https://github.com/redis-rb/redis-cluster-client/compare/zendesk:parking) idea about maintaining some transaction state in `RedisCluster::Client`, but the thing that makes it tricky is that `Redis::Cluster#watch` (which is actually `Redis::Commands::Transactions#watch`) just does `call_v([:watch] + keys])` and then `send_command([:unwatch])` in a begin/rescue block; it doesn't pass the watch block to `RedisClient::Cluster` at all to invoke which means it's difficult to maintain our own state reliably in redis-clustering.

Anyway, as I said, if you can think of a way to make this work nicely I'm all ears.

Thanks for your review!