### PR TITLE
Support watch & unwatch properly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Metrics/ClassLength:
 
 Metrics/ModuleLength:
   Max: 500
+  Exclude:
+    - 'test/**/*'
 
 Metrics/MethodLength:
   Max: 50

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -11,10 +11,13 @@ class RedisClient
       LEFT_BRACKET = '{'
       RIGHT_BRACKET = '}'
       EMPTY_HASH = {}.freeze
+      EMPTY_ARRAY = [].freeze
 
       Detail = Struct.new(
         'RedisCommand',
         :first_key_position,
+        :last_key_position,
+        :key_step,
         :write?,
         :readonly?,
         keyword_init: true
@@ -50,6 +53,8 @@ class RedisClient
 
             acc[row[0].downcase] = ::RedisClient::Cluster::Command::Detail.new(
               first_key_position: row[3],
+              last_key_position: row[4],
+              key_step: row[5],
               write?: row[2].include?('write'),
               readonly?: row[2].include?('readonly')
             )
@@ -68,6 +73,17 @@ class RedisClient
         key = (command[i].is_a?(Array) ? command[i].flatten.first : command[i]).to_s
         hash_tag = extract_hash_tag(key)
         hash_tag.empty? ? key : hash_tag
+      end
+
+      def extract_all_keys(command)
+        keys_start = determine_first_key_position(command)
+        keys_end = determine_last_key_position(command, keys_start)
+        keys_step = determine_key_step(command)
+        return EMPTY_ARRAY if [keys_start, keys_end, keys_step].any?(&:zero?)
+
+        keys_end = [keys_end, command.size - 1].min
+        # use .. inclusive range because keys_end is a valid index.
+        (keys_start..keys_end).step(keys_step).map { |i| command[i] }
       end
 
       def should_send_to_primary?(command)
@@ -99,6 +115,41 @@ class RedisClient
         else
           @commands[name]&.first_key_position.to_i
         end
+      end
+
+      # IMPORTANT: this determines the last key position INCLUSIVE of the last key -
+      # i.e. command[determine_last_key_position(command)] is a key.
+      # This is in line with what Redis returns from COMMANDS.
+      def determine_last_key_position(command, keys_start) # rubocop:disable Metrics/AbcSize
+        case name = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
+        when 'eval', 'evalsha', 'zinterstore', 'zunionstore'
+          # EVALSHA sha1 numkeys [key [key ...]] [arg [arg ...]]
+          # ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE <SUM | MIN | MAX>]
+          command[2].to_i + 2
+        when 'object', 'memory'
+          # OBJECT [ENCODING | FREQ | IDLETIME | REFCOUNT] key
+          # MEMORY USAGE key [SAMPLES count]
+          keys_start
+        when 'migrate'
+          # MIGRATE host port <key | ""> destination-db timeout [COPY] [REPLACE] [AUTH password | AUTH2 username password] [KEYS key [key ...]]
+          command[3].empty? ? (command.length - 1) : 3
+        when 'xread', 'xreadgroup'
+          # XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]
+          keys_start + ((command.length - keys_start) / 2) - 1
+        else
+          # If there is a fixed, non-variable number of keys, don't iterate past that.
+          if @commands[name].last_key_position >= 0
+            @commands[name].last_key_position
+          else
+            command.length - 1
+          end
+        end
+      end
+
+      def determine_key_step(command)
+        name = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
+        # Some commands like EVALSHA have zero as the step in COMMANDS somehow.
+        @commands[name].key_step == 0 ? 1 : @commands[name].key_step
       end
 
       def determine_optional_key_position(command, option_name) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -12,6 +12,7 @@ class RedisClient
       RIGHT_BRACKET = '}'
       EMPTY_HASH = {}.freeze
       EMPTY_ARRAY = [].freeze
+      PRIMARY_COMMANDS = %w[watch unwatch multi exec discard].freeze
 
       Detail = Struct.new(
         'RedisCommand',
@@ -88,7 +89,7 @@ class RedisClient
 
       def should_send_to_primary?(command)
         name = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
-        @commands[name]&.write?
+        @commands[name]&.write? || PRIMARY_COMMANDS.include?(name)
       end
 
       def should_send_to_replica?(command)

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -11,45 +11,83 @@ class RedisClient
         @router = router
         @command_builder = command_builder
         @node_key = nil
+        @node = nil
+        @transaction_commands = []
       end
 
       def call(*command, **kwargs, &_)
         command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
+        ensure_node(command)
+        @transaction_commands << command
+        nil
       end
 
       def call_v(command, &_)
         command = @command_builder.generate(command)
-        ensure_node_key(command)
+        ensure_node(command)
+        @transaction_commands << command
+        nil
       end
-
-      def call_once(*command, **kwargs, &_)
-        command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
-      end
-
-      def call_once_v(command, &_)
-        command = @command_builder.generate(command)
-        ensure_node_key(command)
-      end
+      alias call_once call
+      alias call_once_v call_v
 
       def execute(watch: nil, &block)
-        yield self
-        raise ArgumentError, 'empty transaction' if @node_key.nil?
-
-        node = @router.find_node(@node_key)
-        @router.try_delegate(node, :multi, watch: watch, &block)
+        if watch&.any?
+          execute_with_watch(watch: watch, &block)
+        else
+          execute_without_watch(&block)
+        end
       end
 
       private
 
-      def ensure_node_key(command)
+      def execute_with_watch(watch:)
+        # Validate that all keys to be watched are on the same node
+        watch.each { |key| ensure_node(['WATCH', key]) }
+        # n.b - wrapping this in #try_delegate means we retry the whole transaction on failure, and also
+        # get the recover of e.g. detecting moved slots.
+        @router.try_delegate(@node, :with) do |conn|
+          conn.disable_reconnection do
+            commit_result = nil
+            @router.try_send(conn, :call_v, ['WATCH', *watch], [], retry_count: 0)
+            begin
+              yield self
+              commit_result = @router.try_delegate(conn, :multi, retry_count: 0) do |m|
+                @transaction_commands.each do |cmd|
+                  m.call_v(cmd)
+                end
+              end
+            ensure
+              # unwatch, except if we committed (it's unnescessary) or the connection is broken anyway (it won't work)
+              @router.try_send(conn, :call_v, ['UNWATCH'], [], retry_count: 0) unless commit_result&.any? || !conn.connected?
+            end
+          end
+        end
+      end
+
+      def execute_without_watch
+        # We don't know what node is going to be executed on yet.
+        yield self
+        return [] if @node.nil?
+
+        # Now we know. Accumulate the collected commands and send them to the right connection.
+        @router.try_delegate(@node, :multi) do |m|
+          @transaction_commands.each do |cmd|
+            m.call_v(cmd)
+          end
+        end
+      end
+
+      def ensure_node(command)
         node_key = @router.find_primary_node_key(command)
         raise ConsistencyError, "Client couldn't determine the node to be executed the transaction by: #{command}" if node_key.nil?
 
-        @node_key ||= node_key
-        raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
-
+        if @node.nil?
+          @node = @router.find_node(node_key)
+          @node_key = node_key
+        elsif @node_key != node_key
+          raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
+        end
         nil
       end
     end

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -6,91 +6,152 @@ class RedisClient
   class Cluster
     class Transaction
       ConsistencyError = Class.new(::RedisClient::Error)
+      STARTING_COMMANDS = %w[watch].freeze
+      COMPLETING_COMMANDS = %w[exec discard unwatch].freeze
+
+      def self.command_starts_transaction?(command)
+        STARTING_COMMANDS.include?(::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command))
+      end
+
+      def self.command_ends_transaction?(command)
+        COMPLETING_COMMANDS.include?(::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command))
+      end
 
       def initialize(router, command_builder)
         @router = router
         @command_builder = command_builder
         @node_key = nil
         @node = nil
-        @transaction_commands = []
+        @pool = nil
+        @state = :unstarted
       end
 
-      def call(*command, **kwargs, &_)
-        command = @command_builder.generate(command, kwargs)
-        ensure_node(command)
-        @transaction_commands << command
-        nil
+      attr_reader :node
+
+      def send_command(method, command, *args, &block)
+        # Force-disable retries in transactions
+        method = make_method_once(method)
+
+        # redis-rb wants to do this when it probably doesn't need to.
+        cmd = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
+        if complete?
+          return if COMPLETING_COMMANDS.include?(cmd)
+
+          raise ArgumentError, 'Transaction is already complete'
+        end
+
+        begin
+          ensure_same_node command
+          ret = @router.try_send(@node, method, command, args, retry_count: 0, &block)
+        rescue ::RedisClient::ConnectionError
+          mark_complete # Abort transaction on connection errors
+          raise
+        rescue StandardError
+          # Abort transaction if the first command is a failure.
+          mark_complete if @state == :unstarted
+          raise
+        else
+          @state = :in_progress
+          mark_complete if COMPLETING_COMMANDS.include?(cmd)
+          ret
+        end
       end
 
-      def call_v(command, &_)
-        command = @command_builder.generate(command)
-        ensure_node(command)
-        @transaction_commands << command
-        nil
+      def complete?
+        # The router closes the node on ConnectionError.
+        mark_complete if @state != :complete && @node && !@node.connected?
+        @state == :complete
       end
-      alias call_once call
-      alias call_once_v call_v
 
-      def execute(watch: nil, &block)
-        @router.force_primary do
-          if watch&.any?
-            execute_with_watch(watch: watch, &block)
-          else
-            execute_without_watch(&block)
+      def multi(watch: nil) # rubocop:disable Metrics/AbcSize
+        send_command(:call_once_v, ['WATCH', *watch]) if watch&.any?
+
+        begin
+          command_buffer = MultiBuffer.new
+          yield command_buffer
+          return [] unless command_buffer.commands.any?
+
+          command_buffer.commands.each { |command| ensure_same_node(command) }
+          res = execute_commands_pipelined(command_buffer.commands)
+          # Because we directly called MULTI ... EXEC on the underlying node through the pipeline,
+          # and not in send_command,
+          mark_complete
+          res.last
+        ensure
+          send_command(:call_once_v, ['UNWATCH']) if watch&.any? && !complete?
+        end
+      end
+
+      def ensure_same_node(command)
+        node_key = @router.find_primary_node_key(command)
+        if node_key.nil?
+          # If ome previous command worked out what node to use, this is OK.
+          raise ConsistencyError, "Client couldn't determine the node to be executed the transaction by: #{command}" unless @node
+        elsif @node.nil?
+          # This is the first node key we've seen
+          @node = @router.find_node(node_key)
+          @node_key = node_key
+          if @node.respond_to?(:pool, true)
+            # This is a hack, but we need to check out a connection from the pool and keep it checked out until we unwatch,
+            # if we're using a Pooled backend. Otherwise, we might not run commands on the same session we watched on.
+            # Note that ConnectionPool keeps a reference to this connection in a threadlocal, so we don't need to actually _use_ it
+            # explicitly; it'll get returned from #with like normal.
+            @pool = @node.send(:pool)
+            @node = @pool.checkout
           end
+        elsif node_key != @node_key
+          raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}"
         end
       end
 
       private
 
-      def execute_with_watch(watch:)
-        # Validate that all keys to be watched are on the same node
-        watch.each { |key| ensure_node(['WATCH', key]) }
-        # n.b - wrapping this in #try_delegate means we retry the whole transaction on failure, and also
-        # get the recover of e.g. detecting moved slots.
-        @router.try_delegate(@node, :with) do |conn|
-          conn.disable_reconnection do
-            commit_result = nil
-            @router.try_send(conn, :call_v, ['WATCH', *watch], [], retry_count: 0)
-            begin
-              yield self
-              commit_result = @router.try_delegate(conn, :multi, retry_count: 0) do |m|
-                @transaction_commands.each do |cmd|
-                  m.call_v(cmd)
-                end
-              end
-            ensure
-              # unwatch, except if we committed (it's unnescessary) or the connection is broken anyway (it won't work)
-              @router.try_send(conn, :call_v, ['UNWATCH'], [], retry_count: 0) unless commit_result&.any? || !conn.connected?
-            end
-          end
+      def mark_complete
+        @pool&.checkin
+        @pool = nil
+        @node = nil
+        @state = :complete
+      end
+
+      def make_method_once(method)
+        case method
+        when :call
+          :call_once
+        when :call_v
+          :call_once_v
+        else
+          method
         end
       end
 
-      def execute_without_watch
-        # We don't know what node is going to be executed on yet.
-        yield self
-        return [] if @node.nil?
-
-        # Now we know. Accumulate the collected commands and send them to the right connection.
-        @router.try_delegate(@node, :multi) do |m|
-          @transaction_commands.each do |cmd|
-            m.call_v(cmd)
+      def execute_commands_pipelined(commands)
+        @router.try_delegate(@node, :pipelined, retry_count: 0) do |p|
+          p.call_once_v ['MULTI']
+          commands.each do |command|
+            p.call_once_v command
           end
+          p.call_once_v ['EXEC']
         end
       end
 
-      def ensure_node(command)
-        node_key = @router.find_primary_node_key(command)
-        raise ConsistencyError, "Client couldn't determine the node to be executed the transaction by: #{command}" if node_key.nil?
-
-        if @node.nil?
-          @node = @router.find_node(node_key)
-          @node_key = node_key
-        elsif @node_key != node_key
-          raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
+      class MultiBuffer
+        def initialize
+          @commands = []
         end
-        nil
+
+        def call(*command, **_kwargs, &_)
+          @commands << command
+          nil
+        end
+
+        def call_v(command, &_)
+          @commands << command
+          nil
+        end
+
+        alias call_once call
+        alias call_once_v call_v
+        attr_accessor :commands
       end
     end
   end

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -32,10 +32,12 @@ class RedisClient
       alias call_once_v call_v
 
       def execute(watch: nil, &block)
-        if watch&.any?
-          execute_with_watch(watch: watch, &block)
-        else
-          execute_without_watch(&block)
+        @router.force_primary do
+          if watch&.any?
+            execute_with_watch(watch: watch, &block)
+          else
+            execute_without_watch(&block)
+          end
         end
       end
 

--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -245,6 +245,11 @@ class ClusterController
     rows.select(&:replica?).sample.client
   end
 
+  def select_sacrifice_by_slot(slot)
+    rows = associate_with_clients_and_nodes(@clients)
+    rows.find { |r| r.primary? && r.include_slot?(slot) }.client
+  end
+
   def close
     @clients.each do |client|
       client.close

--- a/test/command_capture_middleware.rb
+++ b/test/command_capture_middleware.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CommandCaptureMiddleware
+  CapturedCommand = Struct.new(:server_url, :command, :pipelined, keyword_init: true) do
+    def inspect
+      "#<#{self.class.name} [on #{server_url}] #{command.join(' ')} >"
+    end
+  end
+
+  def call(command, redis_config)
+    redis_config.custom[:captured_commands] << CapturedCommand.new(
+      server_url: redis_config.server_url,
+      command: command,
+      pipelined: false
+    )
+    super
+  end
+
+  def call_pipelined(commands, redis_config)
+    commands.map do |command|
+      redis_config.custom[:captured_commands] << CapturedCommand.new(
+        server_url: redis_config.server_url,
+        command: command,
+        pipelined: true
+      )
+    end
+    super
+  end
+end

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -103,9 +103,9 @@ class RedisClient
         [
           { command: %w[SET foo 1], want: true },
           { command: %w[GET foo], want: false },
-          { command: %w[UNKNOWN foo bar], want: nil },
-          { command: [], want: nil },
-          { command: nil, want: nil }
+          { command: %w[UNKNOWN foo bar], want: false },
+          { command: [], want: false },
+          { command: nil, want: false }
         ].each_with_index do |c, idx|
           msg = "Case: #{idx}"
           got = cmd.should_send_to_primary?(c[:command])

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -6,6 +6,7 @@ require 'minitest/autorun'
 require 'redis-cluster-client'
 require 'testing_constants'
 require 'cluster_controller'
+require 'command_capture_middleware'
 
 case ENV.fetch('REDIS_CONNECTION_DRIVER', 'ruby')
 when 'hiredis' then require 'hiredis-client'


### PR DESCRIPTION
This is a PR which adds the concept of an "implicit transaction". The `RedisClient::Cluster` object will automatically begin a transaction if a `WATCH` command is issued, and require the user to either call `UNWATCH` or `MULTI ... EXEC/DISCARD` to close it.

Between a watch and an exec/discard/unwatch, the client is locked to a particular node/connection and will reject attempts to read/write to other nodes as transaction consistency issues.

The purpose of this work is to make `RedisClient::Cluster` behave enough like `RedisClient` that `watch` and `multi` from `Redis::Commands::Transactions` in redis-rb work with the cluster client. I outlined the current issue with that in detail in https://github.com/redis-rb/redis-cluster-client/pull/294.

With these changes in redis-cluster-client, these test-cases I wrote for redis-rb pass: https://github.com/redis/redis-rb/compare/master...zendesk:redis-rb:ktsanaktsidis/cluster_txn_tests

@supercaracal , let's keep discussion of this issue in the other PR just so we don't get confused I think :)