### PR TITLE
Raise errors from #pipelined instead of returning them

### DIFF
--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -153,20 +153,14 @@ class RedisClient
       end
 
       def test_pipelined_with_errors
-        got = @client.pipelined do |pipeline|
-          10.times do |i|
-            pipeline.call('SET', "string#{i}", i)
-            pipeline.call('SET', "string#{i}", i, 'too many args')
-            pipeline.call('SET', "string#{i}", i + 10)
+        assert_raises(RedisClient::Cluster::ErrorCollection) do
+          @client.pipelined do |pipeline|
+            10.times do |i|
+              pipeline.call('SET', "string#{i}", i)
+              pipeline.call('SET', "string#{i}", i, 'too many args')
+              pipeline.call('SET', "string#{i}", i + 10)
+            end
           end
-        end
-
-        assert_equal(30, got.size)
-
-        10.times do |i|
-          assert_equal('OK', got[(3 * i) + 0])
-          assert_instance_of(::RedisClient::CommandError, got[(3 * i) + 1])
-          assert_equal('OK', got[(3 * i) + 2])
         end
 
         wait_for_replication


### PR DESCRIPTION
It seems redis-cluster-client intentionally decides to return errors from #pipelined, rather than raising them. I note that in https://github.com/redis-rb/redis-cluster-client/issues/37 it was written:

>> In Grab’s Redis Cluster library, the function
>> Pipeline(PipelineReadOnly) returns a response with an error for
>> individual reply.
>> Instead of returning nil or an error message when err != nil, we could
>> check for errors for each result so successful queries are not affected.
>> This might have minimised the outage’s business impact.
>
> I prefer the above behavior.

It's certainly true that returning the individual results from pipelined gives strictly more information than raising an exception. UNFORTUNATELY, redis-client chooses the _opposite_ option; if any query caused an error, after processing the entire pipeline it raises rather than returns; see:
https://github.com/redis-rb/redis-client/blob/932c5e8909ede7575d56a117773be39f40e2da88/lib/redis_client/connection_mixin.rb#L60

I think consistency with redis-client is very valuable to have for redis-cluster-client, so I would suggest that changing the behaviour here (perhaps with a major version bump?) might be a good idea?

Alternatively, althought I think this would be even _more_ confusing IMO, we could keep the error handling as-is here but patch it in redis-rb to raise instead of return.