### PR TITLE
Refactor key-slot conversion logic

### DIFF
--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -172,21 +172,25 @@ class RedisClient
         find_node(node_key)
       end
 
+      def find_node_key_by_key(key, seed: nil, primary: false)
+        if key && !key.empty?
+          slot = ::RedisClient::Cluster::KeySlotConverter.convert(key)
+          primary ? @node.find_node_key_of_primary(slot) : @node.find_node_key_of_replica(slot)
+        else
+          primary ? @node.any_primary_node_key(seed: seed) : @node.any_replica_node_key(seed: seed)
+        end
+      end
+
       def find_node_key(command, seed: nil)
         key = @command.extract_first_key(command)
-        slot = key.empty? ? nil : ::RedisClient::Cluster::KeySlotConverter.convert(key)
-
-        if @command.should_send_to_primary?(command)
-          @node.find_node_key_of_primary(slot) || @node.any_primary_node_key(seed: seed)
-        else
-          @node.find_node_key_of_replica(slot, seed: seed) || @node.any_replica_node_key(seed: seed)
-        end
+        find_node_key_by_key(key, seed: seed, primary: @command.should_send_to_primary?(command))
       end
 
       def find_primary_node_key(command)
         key = @command.extract_first_key(command)
-        slot = key.empty? ? nil : ::RedisClient::Cluster::KeySlotConverter.convert(key)
-        @node.find_node_key_of_primary(slot)
+        return nil unless key&.size&.> 0
+
+        find_node_key_by_key(key, primary: true)
       end
 
       def find_node(node_key, retry_count: 3)

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -84,7 +84,7 @@ class RedisClient
         [
           { command: %w[SET foo 1], want: 'foo' },
           { command: %w[GET foo], want: 'foo' },
-          { command: %w[GET foo{bar}baz], want: 'bar' },
+          { command: %w[GET foo{bar}baz], want: 'foo{bar}baz' },
           { command: %w[MGET foo bar baz], want: 'foo' },
           { command: %w[UNKNOWN foo bar], want: '' },
           { command: [['GET'], 'foo'], want: 'foo' },
@@ -187,28 +187,6 @@ class RedisClient
         ].each_with_index do |c, idx|
           msg = "Case: #{idx}"
           got = cmd.send(:determine_optional_key_position, c[:params][:command], c[:params][:option_name])
-          assert_equal(c[:want], got, msg)
-        end
-      end
-
-      def test_extract_hash_tag
-        cmd = ::RedisClient::Cluster::Command.load(@raw_clients)
-        [
-          { key: 'foo', want: '' },
-          { key: 'foo{bar}baz', want: 'bar' },
-          { key: 'foo{bar}baz{qux}quuc', want: 'bar' },
-          { key: 'foo}bar{baz', want: '' },
-          { key: 'foo{bar', want: '' },
-          { key: 'foo}bar', want: '' },
-          { key: 'foo{}bar', want: '' },
-          { key: '{}foo', want: '' },
-          { key: 'foo{}', want: '' },
-          { key: '{}', want: '' },
-          { key: '', want: '' },
-          { key: nil, want: '' }
-        ].each_with_index do |c, idx|
-          msg = "Case: #{idx}"
-          got = cmd.send(:extract_hash_tag, c[:key])
           assert_equal(c[:want], got, msg)
         end
       end

--- a/test/redis_client/cluster/test_key_slot_converter.rb
+++ b/test/redis_client/cluster/test_key_slot_converter.rb
@@ -27,6 +27,27 @@ class RedisClient
         got = ::RedisClient::Cluster::KeySlotConverter.convert(multi_byte_key)
         assert_equal(want, got, "Case: #{multi_byte_key}")
       end
+
+      def test_extract_hash_tag
+        [
+          { key: 'foo', want: '' },
+          { key: 'foo{bar}baz', want: 'bar' },
+          { key: 'foo{bar}baz{qux}quuc', want: 'bar' },
+          { key: 'foo}bar{baz', want: '' },
+          { key: 'foo{bar', want: '' },
+          { key: 'foo}bar', want: '' },
+          { key: 'foo{}bar', want: '' },
+          { key: '{}foo', want: '' },
+          { key: 'foo{}', want: '' },
+          { key: '{}', want: '' },
+          { key: '', want: '' },
+          { key: nil, want: '' }
+        ].each_with_index do |c, idx|
+          msg = "Case: #{idx}"
+          got = ::RedisClient::Cluster::KeySlotConverter.extract_hash_tag(c[:key])
+          assert_equal(c[:want], got, msg)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, extract_first_key would perform hashtag extraction on the key it pulled from command; that meant that the "key" it was returning might not actually be the key in the command.

This commit refactors things so that

* extract_first_key actually extracts the first key
* KeySlotConverter.convert does hashtag extraction
* Router's find_node_key and find_primary_node_key can now be implemented in terms of a function "find_node_by_key", because they _actually_ get the key from the command.

This is helpful for the cluster transaction support work, because it means we can re-use the keyslot/hashtag logic for transaction node assignment.