### PR TITLE
Handle timeouts to blocking_v specially via a custom client class

### DIFF
--- a/lib/redis_client/cluster/errors.rb
+++ b/lib/redis_client/cluster/errors.rb
@@ -55,5 +55,7 @@ class RedisClient
         )
       end
     end
+
+    class BlockingReadTimeoutError < ::RedisClient::ReadTimeoutError; end
   end
 end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -13,7 +13,6 @@ class RedisClient
   class Cluster
     class Router
       ZERO_CURSOR_FOR_SCAN = '0'
-      METHODS_FOR_BLOCKING_CMD = %i[blocking_call_v blocking_call].freeze
       TSF = ->(f, x) { f.nil? ? x : f.call(x) }.curry
 
       def initialize(config, concurrent_worker, pool: nil, **kwargs)
@@ -101,9 +100,9 @@ class RedisClient
           retry if retry_count >= 0
         end
         raise
+      rescue ::RedisClient::Cluster::BlockingReadTimeoutError
+        raise
       rescue ::RedisClient::ConnectionError => e
-        raise if METHODS_FOR_BLOCKING_CMD.include?(method) && e.is_a?(RedisClient::ReadTimeoutError)
-
         update_cluster_info!
 
         raise if retry_count <= 0
@@ -133,6 +132,8 @@ class RedisClient
           retry_count -= 1
           retry if retry_count >= 0
         end
+        raise
+      rescue ::RedisClient::Cluster::BlockingReadTimeoutError
         raise
       rescue ::RedisClient::ConnectionError
         update_cluster_info!

--- a/test/redis_client/cluster/node/test_latency_replica.rb
+++ b/test/redis_client/cluster/node/test_latency_replica.rb
@@ -11,7 +11,7 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         end
 
@@ -25,7 +25,7 @@ class RedisClient
           )
 
           got = test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         ensure
           test_topology&.clients&.each_value(&:close)
@@ -34,7 +34,7 @@ class RedisClient
         def test_primary_clients
           got = @test_topology.primary_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -42,14 +42,14 @@ class RedisClient
         def test_replica_clients
           got = @test_topology.replica_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_topology.clients_for_scanning
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/node/test_primary_only.rb
+++ b/test/redis_client/cluster/node/test_primary_only.rb
@@ -12,7 +12,7 @@ class RedisClient
         def test_clients_with_redis_client
           got = @test_topology.clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -28,7 +28,7 @@ class RedisClient
 
           got = test_topology.clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient::Pooled, client)
+            assert_kind_of(::RedisClient::Pooled, client)
             assert_equal('master', client.call('ROLE').first)
           end
         ensure
@@ -38,7 +38,7 @@ class RedisClient
         def test_primary_clients
           got = @test_topology.primary_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -46,7 +46,7 @@ class RedisClient
         def test_replica_clients
           got = @test_topology.replica_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -54,7 +54,7 @@ class RedisClient
         def test_clients_for_scanning
           got = @test_topology.clients_for_scanning
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end

--- a/test/redis_client/cluster/node/test_random_replica.rb
+++ b/test/redis_client/cluster/node/test_random_replica.rb
@@ -11,7 +11,7 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         end
 
@@ -25,7 +25,7 @@ class RedisClient
           )
 
           got = test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         ensure
           test_topology&.clients&.each_value(&:close)
@@ -34,7 +34,7 @@ class RedisClient
         def test_primary_clients
           got = @test_topology.primary_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -42,14 +42,14 @@ class RedisClient
         def test_replica_clients
           got = @test_topology.replica_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_topology.clients_for_scanning
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/node/test_random_replica_or_primary.rb
+++ b/test/redis_client/cluster/node/test_random_replica_or_primary.rb
@@ -11,7 +11,7 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         end
 
@@ -25,7 +25,7 @@ class RedisClient
           )
 
           got = test_topology.clients
-          got.each_value { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |_, v| v.call('ROLE').first }.uniq.sort)
         ensure
           test_topology&.clients&.each_value(&:close)
@@ -34,7 +34,7 @@ class RedisClient
         def test_primary_clients
           got = @test_topology.primary_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -42,14 +42,14 @@ class RedisClient
         def test_replica_clients
           got = @test_topology.replica_clients
           got.each_value do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_topology.clients_for_scanning
-          got.each_value { |client| assert_instance_of(::RedisClient, client) }
+          got.each_value { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -331,14 +331,14 @@ class RedisClient
           msg = "Case: primary only: #{info.node_key}"
           got = -> { @test_node.find_by(info.node_key) }
           if info.primary?
-            assert_instance_of(::RedisClient, got.call, msg)
+            assert_kind_of(::RedisClient, got.call, msg)
           else
             assert_raises(::RedisClient::Cluster::Node::ReloadNeeded, msg, &got)
           end
 
           msg = "Case: scale read: #{info.node_key}"
           got = @test_node_with_scale_read.find_by(info.node_key)
-          assert_instance_of(::RedisClient, got, msg)
+          assert_kind_of(::RedisClient, got, msg)
         end
       end
 


### PR DESCRIPTION
try_send already handles the case where the call is a blocking one specially, but try_delegate does not. This diff detects whether or not a ::RedisClient::ReadTimeoutError is for a blocking call at the source, and wraps it in a special subclass so we can differentiate it.

This is done for two reasons:

* One, it means that we don't retry when a blocking command like `BLPOP`  takes too long and is called through the `#try_delegate` codepath, and also don't unnecessarily refresh the cluster topology in this case either
* More importantly though, it means that the error handling between `try_send` and `try_delegate` is now identical, and we can refactor this into a single helper function in a subsequent PR.