### PR TITLE
Add middleware to ensure Router only handles errors for its clients

### DIFF
--- a/lib/redis_client/cluster/error_identification.rb
+++ b/lib/redis_client/cluster/error_identification.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    module ErrorIdentification
+      def self.client_owns_error?(err, client)
+        err.is_a?(TaggedError) && err.from?(client)
+      end
+
+      module TaggedError
+        attr_accessor :config_instance
+
+        def from?(client)
+          client.config.equal?(config_instance)
+        end
+      end
+
+      module Middleware
+        def connect(config)
+          super
+        rescue RedisClient::Error => e
+          identify_error(e, config)
+          raise
+        end
+
+        def call(_command, config)
+          super
+        rescue RedisClient::Error => e
+          identify_error(e, config)
+          raise
+        end
+        alias call_pipelined call
+
+        private
+
+        def identify_error(err, config)
+          err.singleton_class.include(TaggedError)
+          err.config_instance = config
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you nest usages of RedisClient (perhaps becuase you're scanning from one client whilst inserting into a different cluster, perhaps), it's possible for errors which were raised from one cluster's RedisClients to instead be handled by the wrong cluster.

This is bad, because it can mean processing bogus topology "updates" when e.g. MOVED or ASKING responses get caught by the wrong client.

To fix this, we can add a middleware to our RedisClient instances (through the documented middleware interface), and tag errors at the source based on what config object they came from. This can then be used inside the router to identify errors that it should and should not handle.

---

Although at the moment you have to try pretty hard to get into this situation (`sscan` and `hscan` are probably the main ways to get it), solving this is important for my plan for transaction support. Recall that last year one of the reasons I wanted to wrap the returned `RedisClient` instances from`#with` in a proxy was to make sure they didn't leak errors to each other: https://github.com/redis-rb/redis-cluster-client/pull/298#issuecomment-1845194088

> One reason I think we might need the proxy implementation, though, is what happens if we have two different client instances, that point to totally different Redis clusters? What happens if we get a MOVED response here:
>
> ```
> client1.with(key: '{slot1}', retry_count: 1) do |conn1|
>   client2.with(key: '{slot2}', retry_count: 1) do |conn2|
>     conn1.call('SET', '{slot1}key', 'value')
>   end
> end
> ```
>
> The MOVED response is for client1's cluster, but client2's #with method is what catches the exception. We'd then wind up moving the slot on the wrong client instance. The benefit of the proxy object around conn is that we can catch the exceptions right there with the client that generated them, so we know for sure we're the cluster that the exception was for.

If we do this in RedisClient middleware instead, we can identify errors correctly right at the source, and that should make it safe to pass the raw `RedisClient` instances to callers, removing the need for a proxy over the top of it.