### PR TITLE
Validate key slots used with RedisCluster::Client#with

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -78,12 +78,18 @@ class RedisClient
         end
       end
 
+      class SingleNodeRedisClient < ::RedisClient
+      end
+
       class Config < ::RedisClient::Config
         def initialize(scale_read: false, middlewares: nil, **kwargs)
           @scale_read = scale_read
           middlewares ||= []
           middlewares.unshift ErrorIdentification::Middleware
-          super(middlewares: middlewares, **kwargs)
+          super(
+            middlewares: middlewares,
+            client_implementation: SingleNodeRedisClient,
+            **kwargs)
         end
 
         private

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -8,6 +8,7 @@ require 'redis_client/cluster/node/primary_only'
 require 'redis_client/cluster/node/random_replica'
 require 'redis_client/cluster/node/random_replica_or_primary'
 require 'redis_client/cluster/node/latency_replica'
+require 'redis_client/cluster/pinning'
 
 class RedisClient
   class Cluster
@@ -79,6 +80,7 @@ class RedisClient
       end
 
       class SingleNodeRedisClient < ::RedisClient
+        include Pinning::ClientMixin
       end
 
       class Config < ::RedisClient::Config
@@ -86,6 +88,7 @@ class RedisClient
           @scale_read = scale_read
           @cluster_commands = cluster_commands
           middlewares ||= []
+          middlewares.unshift Pinning::ClientMiddleware
           middlewares.unshift ErrorIdentification::Middleware
           super(
             middlewares: middlewares,

--- a/lib/redis_client/cluster/pinning.rb
+++ b/lib/redis_client/cluster/pinning.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Cluster
+    module Pinning
+      module ClientMixin
+        attr_reader :locked_key_slot
+
+        # This gets called when handing out connections in Cluster#with to lock the returned
+        # connections to a given slot.
+        def locked_to_key_slot(key_slot)
+          raise ArgumentError, 'recursive slot locking is not allowed' if @locked_key_slot
+
+          begin
+            @locked_key_slot = key_slot
+            yield
+          ensure
+            @locked_key_slot = nil
+          end
+        end
+      end
+
+      # This middleware is what actually enforces the slot locking above.
+      module ClientMiddleware
+        def initialize(client)
+          @client = client
+          super
+        end
+
+        def assert_slot_valid!(command, config) # rubocop:disable Metrics/AbcSize
+          return unless @client.locked_key_slot
+          return unless config.cluster_commands.loaded?
+
+          keys = config.cluster_commands.extract_all_keys(command)
+          key_slots = keys.map { |k| ::RedisClient::Cluster::KeySlotConverter.convert(k) }
+          locked_slot = ::RedisClient::Cluster::KeySlotConverter.convert(@client.locked_key_slot)
+          return if key_slots.all? { |slot| slot ==  locked_slot }
+
+          key_slot_pairs = keys.zip(key_slots).map { |key, slot| "#{key} => #{slot}" }.join(', ')
+          raise ::RedisClient::Cluster::Transaction::ConsistencyError, <<~MESSAGE
+            Connection is pinned to slot #{locked_slot} (via key #{@client.locked_key_slot}). \
+            However, command #{command.inspect} has keys hashing to slots #{key_slot_pairs}. \
+            Transactions in redis cluster must only refer to keys hashing to the same slot.
+          MESSAGE
+        end
+
+        def call(command, config)
+          assert_slot_valid!(command, config)
+          super
+        end
+
+        def call_pipelined(command, config)
+          assert_slot_valid!(command, config)
+          super
+        end
+      end
+    end
+  end
+end

--- a/test/redis_client/cluster/node/test_latency_replica.rb
+++ b/test/redis_client/cluster/node/test_latency_replica.rb
@@ -12,21 +12,21 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_clients_with_pooled_redis_client
           test_node = make_node(pool: { timeout: 3, size: 2 })
           got = test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_primary_clients
           got = @test_node.primary_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -34,14 +34,14 @@ class RedisClient
         def test_replica_clients
           got = @test_node.replica_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_node.clients_for_scanning
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/node/test_primary_only.rb
+++ b/test/redis_client/cluster/node/test_primary_only.rb
@@ -13,7 +13,7 @@ class RedisClient
         def test_clients_with_redis_client
           got = @test_node.clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -22,7 +22,7 @@ class RedisClient
           test_node = make_node(pool: { timeout: 3, size: 2 })
           got = test_node.clients
           got.each do |client|
-            assert_instance_of(::RedisClient::Pooled, client)
+            assert_kind_of(::RedisClient::Pooled, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -30,7 +30,7 @@ class RedisClient
         def test_primary_clients
           got = @test_node.primary_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -38,7 +38,7 @@ class RedisClient
         def test_replica_clients
           got = @test_node.replica_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -46,7 +46,7 @@ class RedisClient
         def test_clients_for_scanning
           got = @test_node.clients_for_scanning
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end

--- a/test/redis_client/cluster/node/test_random_replica.rb
+++ b/test/redis_client/cluster/node/test_random_replica.rb
@@ -12,21 +12,21 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_clients_with_pooled_redis_client
           test_node = make_node(pool: { timeout: 3, size: 2 })
           got = test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_primary_clients
           got = @test_node.primary_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -34,14 +34,14 @@ class RedisClient
         def test_replica_clients
           got = @test_node.replica_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_node.clients_for_scanning
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/node/test_random_replica_or_primary.rb
+++ b/test/redis_client/cluster/node/test_random_replica_or_primary.rb
@@ -12,21 +12,21 @@ class RedisClient
 
         def test_clients_with_redis_client
           got = @test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_clients_with_pooled_redis_client
           test_node = make_node(pool: { timeout: 3, size: 2 })
           got = test_node.clients
-          got.each { |client| assert_instance_of(::RedisClient::Pooled, client) }
+          got.each { |client| assert_kind_of(::RedisClient::Pooled, client) }
           assert_equal(%w[master slave], got.map { |v| v.call('ROLE').first }.uniq.sort)
         end
 
         def test_primary_clients
           got = @test_node.primary_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('master', client.call('ROLE').first)
           end
         end
@@ -34,14 +34,14 @@ class RedisClient
         def test_replica_clients
           got = @test_node.replica_clients
           got.each do |client|
-            assert_instance_of(::RedisClient, client)
+            assert_kind_of(::RedisClient, client)
             assert_equal('slave', client.call('ROLE').first)
           end
         end
 
         def test_clients_for_scanning
           got = @test_node.clients_for_scanning
-          got.each { |client| assert_instance_of(::RedisClient, client) }
+          got.each { |client| assert_kind_of(::RedisClient, client) }
           assert_equal(TEST_SHARD_SIZE, got.size)
         end
 

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -297,14 +297,14 @@ class RedisClient
           msg = "Case: primary only: #{info.node_key}"
           got = -> { @test_node.find_by(info.node_key) }
           if info.primary?
-            assert_instance_of(::RedisClient, got.call, msg)
+            assert_kind_of(::RedisClient, got.call, msg)
           else
             assert_raises(::RedisClient::Cluster::Node::ReloadNeeded, msg, &got)
           end
 
           msg = "Case: scale read: #{info.node_key}"
           got = @test_node_with_scale_read.find_by(info.node_key)
-          assert_instance_of(::RedisClient, got, msg)
+          assert_kind_of(::RedisClient, got, msg)
         end
       end
 

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -533,8 +533,6 @@ class RedisClient
       end
 
       def test_pinning_cross_slot
-        skip 'This is not implemented yet!'
-
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.with(hashtag: 'slot1') do |conn|
             conn.call('GET', '{slot2}')


### PR DESCRIPTION
The overall objective of this PR is to unskip the test which asserts that `TransactionConsistencyError` is raised when using a key belonging to the wrong slot on a connection returned from `#with`. i.e. it makes this test pass:

```
        assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
          @client.with(hashtag: 'slot1') do |conn|
            conn.call('GET', '{slot2}')
          end
        end
```

In order to get there, though, there is a bit of a journey. I've broken it up into five separate commits, which I can make separate PR's for - I did want to show you the whole picture before we drill down on the detail however.

Firstly, and sadly, I discovered that we do actually need to  make a custom subclass of `RedisClient`, and pass that as `client_implementation:` in our custom config class. I had previously thought I could implement the slot validation just with middleware, but we need a way to communicate between `#with`, which just has access to the client object, and the middleware. By implementing a custom subclass, we can define a method `Client#locked_to_key_slot`, which essentially turns on and off the middleware by setting a flag on the client object which the middleware can see.

I do realise that we'd discussed doing this without the client subclass, but unfortunately I could not find another way.

The next phase of this PR involves getting access to the `RedisCluster::Client::Command` object from inside the middleware. There's a bit of circularity here, because obviously we need clients to run COMMAND on, but we need the Command object inside the client middleware (to be able to call `#extract_all_keys` on passed in commands). I resolved this by turning `Command` into a long-lived object which gets passed into the `Node::Config` redisclient config objects.

Once all that's done, we're finally in a position to actually implement the "lock to a single slot"; that then turns out to be pretty simple in a single file `pinning.rb`; we just check if the connection is currently supposed to be pinned, and compare the pinned slot against `Command#extract_all_keys(command)` if so.

Lets debate the general direction of this PR, and I can cut it up into smaller pieces for more detailed review once we're OK with that perhaps?