### PR TITLE
Fix error identification middleware calling into the wrong super

### DIFF
--- a/lib/redis_client/cluster/error_identification.rb
+++ b/lib/redis_client/cluster/error_identification.rb
@@ -29,7 +29,13 @@ class RedisClient
           identify_error(e, config)
           raise
         end
-        alias call_pipelined call
+
+        def call_pipelined(_command, config)
+          super
+        rescue RedisClient::Error => e
+          identify_error(e, config)
+          raise
+        end
 
         private
 


### PR DESCRIPTION
I hbad thought that because the body of `call` and `call_super` are identical, it would be OK to just alias them. However, that means they both call into the `call` super, and never the `call_pipelined` super, as it turns out, which is wrong.

```
irb(main):001* class Base
irb(main):002*   def hello_1 = puts "hello1"
irb(main):003*   def hello_2 = puts "hello2"
irb(main):004> end
=> :hello_2
irb(main):005* class Derived < Base
irb(main):006*   def hello_1
irb(main):007*     puts "about to hello"
irb(main):008*     super
irb(main):009*   end
irb(main):010*   alias hello_2 hello_1
irb(main):011> end
=> nil
irb(main):012> Derived.new.hello_1
about to hello
hello1
=> nil
irb(main):013> Derived.new.hello_2
about to hello
hello1
=> nil
```

I was surprised to learn this! I don't know what bug this is actually causing but I'm sure it can't be good.