### PR TITLE
Validate keys when a raw connection is checked out with #with

### DIFF
--- a/lib/redis_client/cluster/pinned_connection_delegator.rb
+++ b/lib/redis_client/cluster/pinned_connection_delegator.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'delegate'
+class RedisClient
+  class Cluster
+    class PinnedConnectionDelegator < SimpleDelegator
+      METHOD_WRAPPERS = {
+        # These methods return a Pipeline or Multi to the yielded block which itself
+        # requires wrapping.
+        %i[pipelined multi] => lambda do |*args, **kwargs, &block|
+          super(*args, **kwargs, &wrap_yielded_object(block))
+        end,
+        # These are various commanding methods, each of which has a different signature
+        # which we need to understand to extract the commands properly
+        %i[call call_once] => lambda do |*command, **kwargs, &block|
+          validate_slot! command
+          super(*command, **kwargs, &block)
+        end,
+        %i[call_v call_once_v] => lambda do |command, &block|
+          validate_slot! command
+          super command, &block
+        end,
+        %i[blocking_call] => lambda do |timeout, *command, **kwargs, &block|
+          validate_slot! command
+          super timeout, *command, **kwargs, &block
+        end,
+        %i[blocking_call_v] => lambda do |timeout, command, &block|
+          validate_slot! command
+          super timeout, command, &block
+        end
+      }.freeze
+
+      def initialize(connection, locked_key_slot:, cluster_commands:)
+        @locked_key_slot = locked_key_slot
+        @cluster_commands = cluster_commands
+        super(connection)
+
+        # Set up the slot validation for the set of methods which this object
+        # implements. Note that we might be wrapping a RedisClient, RedisClient::Multi,
+        # or RedisClient::Pipeline object, and they do not all respond to the same set of
+        # methods. Hence, we need to dynamically detect what we're wrapping and define
+        # the correct methods.
+        METHOD_WRAPPERS.each do |methods, impl|
+          methods.each do |method|
+            define_singleton_method(method, &impl) if respond_to?(method)
+          end
+        end
+      end
+
+      private
+
+      def validate_slot!(command)
+        keys = @cluster_commands.extract_all_keys(command)
+        key_slots = keys.map { |k| ::RedisClient::Cluster::KeySlotConverter.convert(k) }
+        locked_slot = ::RedisClient::Cluster::KeySlotConverter.convert(@locked_key_slot)
+
+        return if key_slots.all? { |slot| slot ==  locked_slot }
+
+        key_slot_pairs = keys.zip(key_slots).map { |key, slot| "#{key} => #{slot}" }.join(', ')
+        raise ::RedisClient::Cluster::Transaction::ConsistencyError, <<~MESSAGE
+          Connection is pinned to slot #{locked_slot} (via key #{@locked_key_slot}). \
+          However, command #{command.inspect} has keys hashing to slots #{key_slot_pairs}. \
+          Transactions in redis cluster must only refer to keys hashing to the same slot.
+        MESSAGE
+      end
+
+      # This method ensures that calls to #pipelined, #multi, etc wrap yielded redis-callable objects
+      # back in the pinning delegator
+      def wrap_yielded_object(orig_block)
+        return nil if orig_block.nil?
+
+        proc do |clientish|
+          orig_block.call(
+            self.class.new(clientish, locked_key_slot: @locked_key_slot, cluster_commands: @cluster_commands)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -188,6 +188,10 @@ class RedisClient
         @command.exists?(name)
       end
 
+      def cluster_commands
+        @command
+      end
+
       def assign_redirection_node(err_msg)
         _, slot, node_key = err_msg.split
         slot = slot.to_i

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -24,9 +24,9 @@ class RedisClient
     InvalidClientConfigError = Class.new(::RedisClient::Error)
 
     attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout,
-                :connect_with_original_config, :startup_nodes
+                :connect_with_original_config, :startup_nodes, :client_side_slot_validation
 
-    def initialize(
+    def initialize( # rubocop:disable Metrics/ParameterLists
       nodes: DEFAULT_NODES,
       replica: false,
       replica_affinity: :random,
@@ -36,6 +36,7 @@ class RedisClient
       client_implementation: ::RedisClient::Cluster, # for redis gem
       slow_command_timeout: SLOW_COMMAND_TIMEOUT,
       command_builder: ::RedisClient::CommandBuilder,
+      client_side_slot_validation: true,
       **client_config
     )
 
@@ -51,6 +52,7 @@ class RedisClient
       @connect_with_original_config = connect_with_original_config
       @client_implementation = client_implementation
       @slow_command_timeout = slow_command_timeout
+      @client_side_slot_validation = client_side_slot_validation
     end
 
     def inspect


### PR DESCRIPTION
If a raw connection is obtained via #with, this commit causes that connection to in fact be wrapped in a delegator. The delegator will enforce that any keys used with the raw connection belong to the slot that the #with call was pinned to.

---

This is a replacement for https://github.com/redis-rb/redis-cluster-client/pull/314 which takes your feedback into account:

* There is a config option for whether or not slot validation is enabled
* The validation is achieved through proxying, rather than subclassing

I do want to give a bit of insight into why I designed it this way, using `SimpleDelegator` and dynamically detecting which methods to respond to and such. IMO there are two kinds of simplicity we can have here - a simple _implementation_, which means the code in here is simple, or a simple _interface_, which means we present an API which does what people expect and is hard to misuse.

In my opinion, it's more important for the interface to be simple, than for the implementation to be simple. In this case, if we're proxying an object, a "simple, unsurprising interface" is that it has exactly the same methods which the underlying object has. That means not missing any methods which `RedisClient` has (`SimpleDelegator` takes care of that for us), and not adding any additional methods which e.g. `RedisClient:Multi` doesn't normally have (i.e. the check for `define_singleton_method if respond_to?(method)`.

It makes the inside of the `PinnedConnectionDelegator` implementation a little more complex, but it makes it less surprising to use for callers, which I think is the most important thing.