### PR TITLE
fix: don't call the block twice during the transaction

### DIFF
--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -89,8 +89,10 @@ class RedisClient
       pipeline.execute
     end
 
-    def multi(watch: nil, &block)
-      ::RedisClient::Cluster::Transaction.new(@router, @command_builder).execute(watch: watch, &block)
+    def multi(watch: nil)
+      transaction = ::RedisClient::Cluster::Transaction.new(@router, @command_builder, watch)
+      yield transaction
+      transaction.execute
     end
 
     def with(key: nil, hashtag: nil, write: true, retry_count: 0, &block)

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -162,6 +162,11 @@ class RedisClient
         end
       end
 
+      def find_primary_node_by_slot(slot)
+        node_key = @node.find_node_key_of_primary(slot)
+        find_node(node_key)
+      end
+
       def find_node_key(command, seed: nil)
         key = @command.extract_first_key(command)
         find_node_key_by_key(key, seed: seed, primary: @command.should_send_to_primary?(command))

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -1,56 +1,113 @@
 # frozen_string_literal: true
 
 require 'redis_client'
+require 'redis_client/cluster/pipeline'
 
 class RedisClient
   class Cluster
     class Transaction
       ConsistencyError = Class.new(::RedisClient::Error)
 
-      def initialize(router, command_builder)
+      def initialize(router, command_builder, watch)
         @router = router
         @command_builder = command_builder
-        @node_key = nil
+        @watch = watch
+        @pipeline = ::RedisClient::Pipeline.new(@command_builder)
+        @node = nil
+        @retryable = true
       end
 
-      def call(*command, **kwargs, &_)
+      def call(*command, **kwargs, &block)
         command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
+        prepare_once(command)
+        @pipeline.call_v(command, &block)
       end
 
-      def call_v(command, &_)
+      def call_v(command, &block)
         command = @command_builder.generate(command)
-        ensure_node_key(command)
+        prepare_once(command)
+        @pipeline.call_v(command, &block)
       end
 
-      def call_once(*command, **kwargs, &_)
+      def call_once(*command, **kwargs, &block)
+        @retryable = false
         command = @command_builder.generate(command, kwargs)
-        ensure_node_key(command)
+        prepare_once(command)
+        @pipeline.call_once_v(command, &block)
       end
 
-      def call_once_v(command, &_)
+      def call_once_v(command, &block)
+        @retryable = false
         command = @command_builder.generate(command)
-        ensure_node_key(command)
+        prepare_once(command)
+        @pipeline.call_once_v(command, &block)
       end
 
-      def execute(watch: nil, &block)
-        yield self
-        raise ArgumentError, 'empty transaction' if @node_key.nil?
-
-        node = @router.find_node(@node_key)
-        @router.try_delegate(node, :multi, watch: watch, &block)
+      def execute
+        case @node
+        when ::RedisClient then send_pipeline(@node, @pipeline, @watch, @retryable)
+        when ::RedisClient::Pooled then @node.with { |node| send_pipeline(node, @pipeline, @watch, @retryable) }
+        when nil then raise ArgumentError, 'empty transaction'
+        else raise NotImplementedError, "#{client.class.name}#multi for cluster client"
+        end
       end
 
       private
 
-      def ensure_node_key(command)
+      def prepare_once(command)
+        return unless @node.nil?
+
         node_key = @router.find_primary_node_key(command)
-        raise ConsistencyError, "Client couldn't determine the node to be executed the transaction by: #{command}" if node_key.nil?
+        raise ConsistencyError, "cloud not find the node: #{command.join(' ')}" if node_key.nil?
 
-        @node_key ||= node_key
-        raise ConsistencyError, "The transaction should be done for single node: #{@node_key}, #{node_key}" if node_key != @node_key
+        @node = @router.find_node(node_key)
+        @pipeline.call('WATCH', *@watch) unless @watch.nil? || @watch.empty?
+        @pipeline.call('MULTI')
+      end
 
-        nil
+      def send_pipeline(client, pipeline, watch, retryable)
+        pipeline.call('EXEC')
+        pipeline.call('UNWATCH', *watch) unless watch.nil? || watch.empty?
+
+        results = client.ensure_connected_cluster_scoped(retryable: retryable) do |connection|
+          commands = pipeline._commands
+          client.middlewares.call_pipelined(commands, client.config) do
+            connection.call_pipelined(commands, nil)
+          rescue ::RedisClient::CommandError => e
+            handle_command_error!(commands, e)
+          end
+        end
+
+        pipeline._coerce!(results)
+        idx = watch.nil? || watch.empty? ? -1 : -2
+        results[idx]
+      end
+
+      def handle_command_error!(commands, err)
+        if err.message.start_with?('CROSSSLOT')
+          raise ConsistencyError, err.message
+        elsif err.message.start_with?('MOVED', 'ASK')
+          handle_redirection(commands, err)
+        else
+          raise err
+        end
+      end
+
+      def handle_redirection(commands, err)
+        ensure_the_same_node!(commands)
+
+        # TODO: fix the handling
+        raise ConsistencyError, err.message
+      end
+
+      def ensure_the_same_node!(commands)
+        commands.each do |command|
+          node_key = @router.find_primary_node_key(command)
+          next if node_key.nil?
+
+          node = @router.find_node(node_key)
+          raise ConsistencyError, 'the transaction should be executed to the same slot in the same node' if @node != node
+        end
       end
     end
   end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -266,10 +266,15 @@ class RedisClient
 
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi(watch: %w[key1 key2]) do |tx|
-            tx.call('ECHO', 'START')
             tx.call('SET', '{key}1', '1')
             tx.call('SET', '{key}2', '2')
-            tx.call('ECHO', 'FINISH')
+          end
+        end
+
+        assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
+          @client.multi(watch: %w[{hey}1 {hey}2]) do |tx|
+            tx.call('SET', '{key}1', '1')
+            tx.call('SET', '{key}2', '2')
           end
         end
 

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -234,7 +234,7 @@ class RedisClient
           end
         end
 
-        assert_raises(::RedisClient::CommandError, 'CROSSSLOT keys') do
+        assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi do |t|
             t.call('MSET', 'key1', '1', 'key2', '2')
             t.call('MSET', 'key1', '1', 'key3', '3')

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -247,6 +247,20 @@ class RedisClient
         end
       end
 
+      def test_transaction_with_watch
+        got = @client.multi(watch: %w[{key}1 {key}2]) do |tx|
+          tx.call('SET', '{key}1', '1')
+          tx.call('SET', '{key}2', '2')
+        end
+
+        assert_equal(%w[OK OK], got)
+        assert_equal(%w[1 2], @client.call('MGET', '{key}1', '{key}2'))
+      end
+
+      def test_transaction_against_optimistic_locking
+        skip("TODO: It's hard to hook in the middle of the transaction.")
+      end
+
       def test_pubsub_without_subscription
         pubsub = @client.pubsub
         assert_nil(pubsub.next_event(0.01))

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -142,17 +142,27 @@ class TestAgainstClusterState < TestingWrapper
   class ScaleReadRandom < TestingWrapper
     include Mixin
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding
       keys = nil
       do_resharding_test { |ks| keys = ks }
       keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding_with_pipelining
       keys = nil
       do_resharding_test { |ks| keys = ks }
       values = @client.pipelined { |pipeline| keys.each { |key| pipeline.call('GET', key) } }
       keys.each_with_index { |key, i| assert_equal(key, values[i], "Case: GET: #{key}") }
+    end
+
+    # FIXME: https://github.com/redis/redis/issues/11312
+    def test_the_state_of_cluster_resharding_with_transaction
+      keys = nil
+      do_resharding_test { |ks| keys = ks }
+      @client.multi { |tx| keys.each { |key| tx.call('SET', key, key) } }
+      keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
     private
@@ -171,17 +181,27 @@ class TestAgainstClusterState < TestingWrapper
   class ScaleReadRandomWithPrimary < TestingWrapper
     include Mixin
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding
       keys = nil
       do_resharding_test { |ks| keys = ks }
       keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding_with_pipelining
       keys = nil
       do_resharding_test { |ks| keys = ks }
       values = @client.pipelined { |pipeline| keys.each { |key| pipeline.call('GET', key) } }
       keys.each_with_index { |key, i| assert_equal(key, values[i], "Case: GET: #{key}") }
+    end
+
+    # FIXME: https://github.com/redis/redis/issues/11312
+    def test_the_state_of_cluster_resharding_with_transaction
+      keys = nil
+      do_resharding_test { |ks| keys = ks }
+      @client.multi { |tx| keys.each { |key| tx.call('SET', key, key) } }
+      keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
     private
@@ -200,17 +220,27 @@ class TestAgainstClusterState < TestingWrapper
   class ScaleReadLatency < TestingWrapper
     include Mixin
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding
       keys = nil
       do_resharding_test { |ks| keys = ks }
       keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
+    # FIXME: https://github.com/redis/redis/issues/11312
     def test_the_state_of_cluster_resharding_with_pipelining
       keys = nil
       do_resharding_test { |ks| keys = ks }
       values = @client.pipelined { |pipeline| keys.each { |key| pipeline.call('GET', key) } }
       keys.each_with_index { |key, i| assert_equal(key, values[i], "Case: GET: #{key}") }
+    end
+
+    # FIXME: https://github.com/redis/redis/issues/11312
+    def test_the_state_of_cluster_resharding_with_transaction
+      keys = nil
+      do_resharding_test { |ks| keys = ks }
+      @client.multi { |tx| keys.each { |key| tx.call('SET', key, key) } }
+      keys.each { |key| assert_equal(key, @client.call('GET', key), "Case: GET: #{key}") }
     end
 
     private

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -59,6 +59,20 @@ class TestAgainstClusterState < TestingWrapper
       end
     end
 
+    def test_the_state_of_cluster_resharding_with_transaction
+      do_resharding_test do |keys|
+        @client.multi do |tx|
+          keys.each { |key| tx.call('SET', key, key) }
+        end
+
+        keys.each do |key|
+          want = key
+          got = @client.call('GET', key)
+          assert_equal(want, got, "Case: GET: #{key}")
+        end
+      end
+    end
+
     def test_the_state_of_cluster_resharding_with_pipelining_on_new_connection
       # This test is excercising a very delicate race condition; i think the use of @client to set
       # the keys in do_resharding_test is actually causing the race condition not to happen, so this


### PR DESCRIPTION
* This isn't an intended behavior because of the cutting corners in the following pull request.
  * #277
* Although there is a discussion for the design regarding `#with` and `#multi` method implementations, this behavior should be fixed in advance because it's certainly a bug.
  * #299