### PR TITLE
Fix two separate but related problems with watch retry handling

### DIFF
--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -98,9 +98,9 @@ class RedisClient
         return transaction.execute
       end
 
-      ::RedisClient::Cluster::OptimisticLocking.new(@router).watch(watch) do |c, slot|
+      ::RedisClient::Cluster::OptimisticLocking.new(@router).watch(watch) do |c, slot, asking|
         transaction = ::RedisClient::Cluster::Transaction.new(
-          @router, @command_builder, node: c, slot: slot
+          @router, @command_builder, node: c, slot: slot, asking: asking
         )
         yield transaction
         transaction.execute


### PR DESCRIPTION
This PR contains two commits which each fix an aspect of retry handling with WATCH/MULTI.

---
First patch:  https://github.com/redis-rb/redis-cluster-client/commit/954668291e665a59e264f906355fa86f064abf37

* It's important that all of a transaction actually happens on the same connection, with no transparent reconnection allowed inside ::RedisClient. So, we wrap a watch transaction in ensure_connected_cluster_scoped(retryable: false).
* We don't need to call UNWATCH on connection errors (since the connection state is already broken). redis-rb and RedisClient don't do this either.

---
Second patch: https://github.com/redis-rb/redis-cluster-client/commit/99de3d3b06deeb0a598b2d8a3308b89bf55d8401

If we have a WATCH, then the MULTI _must_ exec on exactly that node; it should not be allowed for that to be redirected to a different node, because then the MULTI isn't on the same connection as the WATCH anymore!

The first part of this patch fixes this by disabling redirection handling in transaction.rb if we are in a watch. I also added a test test_the_state_of_cluster_resharding_with_reexecuted_watch for this.

That means that the _user block_ is also re-executed in this case; that's actually what we want. If WATCH is re-executed, then it's also vital that the user code which does redis reads is also re-executed, so that the code can make the decision about what to put in the transaction again (based on potentially updated information).

However, the second part of this patch is a lot trickier...

This change causes a different test, test_the_state_of_cluster_resharding_with_transaction_and_watch, to
break. That test is asserting that
- if we watch something where the slot is in the middle of migrating between nodes,
- and all the keys we wanted to watch are on the new node,
- that the client correctly retries the transaction with ASKING against the new node

Disabling redirection handling obviously makes this stop working, and it _is_ possible to handle this case correctly. We need to record whether or not we had to issue an ASKING on the WATCH for the transaction, and if so, pre-emptively issue an ASKING on the MULTI too. That's because this slot is not yet actually assigned to the node we're connected to (it's IMPORTING).

It may well not be worth it, and I'm also OK with just failing WATCH/MULTI on slots which are currently migrating. That would imply:
- Keeping test_the_state_of_cluster_resharding_with_reexecuted_watch
- Deleting test_the_state_of_cluster_resharding_with_transaction_and_watch