### PR TITLE
Add an explicit #watch method to RedisClient::Cluster

### DIFF
--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -91,19 +91,16 @@ class RedisClient
       pipeline.execute
     end
 
-    def multi(watch: nil)
+    def multi(watch: nil, &block)
       if watch.nil? || watch.empty?
         transaction = ::RedisClient::Cluster::Transaction.new(@router, @command_builder)
         yield transaction
         return transaction.execute
       end
 
-      ::RedisClient::Cluster::OptimisticLocking.new(@router).watch(watch) do |c, slot|
-        transaction = ::RedisClient::Cluster::Transaction.new(
-          @router, @command_builder, node: c, slot: slot
-        )
-        yield transaction
-        transaction.execute
+      watcher = ::RedisClient::Cluster::OptimisticLocking.new(@router, @command_builder)
+      watcher.watch(watch) do
+        watcher.multi(&block)
       end
     end
 
@@ -127,6 +124,18 @@ class RedisClient
     end
 
     private
+
+
+    # This API is called by redis-clustering/redis-rb, but requries further refinement before we commit
+    # to making it part of redis-cluster-client's official public API.
+    def watch(keys)
+      raise ArgumentError, "#{self.class.name}#watch requires a block for the initial watch" unless block_given?
+
+      watcher = ::RedisClient::Cluster::OptimisticLocking.new(@router, @command_builder)
+      watcher.watch(keys) do
+        yield watcher
+      end
+    end
 
     def process_with_arguments(key, hashtag) # rubocop:disable Metrics/CyclomaticComplexity
       raise ArgumentError, 'Only one of key or hashtag may be provided' if key && hashtag

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -46,7 +46,6 @@ class RedisClient
         when 'memory'   then send_memory_command(method, command, args, &block)
         when 'script'   then send_script_command(method, command, args, &block)
         when 'pubsub'   then send_pubsub_command(method, command, args, &block)
-        when 'watch'    then send_watch_command(command, &block)
         when 'acl', 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
           @node.call_all(method, command, args).first.then(&TSF.call(block))
         when 'flushall', 'flushdb'
@@ -308,19 +307,6 @@ class RedisClient
           @node.call_replicas(method, command, args).reject(&:empty?).map { |e| Hash[*e] }
                .reduce({}) { |a, e| a.merge(e) { |_, v1, v2| v1 + v2 } }.then(&TSF.call(block))
         else assign_node(command).public_send(method, *args, command, &block)
-        end
-      end
-
-      # for redis-rb
-      def send_watch_command(command)
-        raise ::RedisClient::Cluster::Transaction::ConsistencyError, 'A block required. And you need to use the block argument as a client for the transaction.' unless block_given?
-
-        ::RedisClient::Cluster::OptimisticLocking.new(self).watch(command[1..]) do |c, slot|
-          transaction = ::RedisClient::Cluster::Transaction.new(
-            self, @command_builder, node: c, slot: slot
-          )
-          yield transaction
-          transaction.execute
         end
       end
 


### PR DESCRIPTION
This returns a "watcher" object, which can either be used for three things:

* To add keys to be watched on the same connection (by calling #watch
* To begin a MULTI transaction on the connection (by calling #multi)
* To UNWATCH the connection and return it to its original state (by calling... #unwatch)

This means that the following pattern becomes possible in redis-cluster-client:

```
client.watch(["{slot}k1", "{slot}k2"]) do |watcher|
  # Further reads can be performed with client directly; this is
  # perfectly safe and they will be individually redirected if required
  # as normal.
  # If a read on a slot being watched is redirected, that's also OK,
  # because it means the final EXEC will fail (since the watch got
  # modified).
  current_value = client.call('GET', '{slot}k1')
  some_other_thing = client.call('GET', '{slot}something_unwatched')

  # You can add more keys to the watch if required
  # This could raise a redireciton error, and cause the whole watch
  # block to be re-attempted
  watcher.watch('{slot}differet_key')
  different_value = client.call('GET', '{slot}different_key')

  if do_transaction?
    # Once you're ready to perform a transaction, you can use multi...
    watcher.multi do |tx|
      # tx is now a pipeliend RedisClient::Cluster::Transaction
      # instance, like normal multi
      tx.call('SET', '{slot}k1', 'new_value')
      tx.call('SET', '{slot}k2', 'new_value')
    end
    # At this point, the transaction is committed
  else
    # You can abort the transaction by calling unwatch
    # (this will also happen if an exception is thrown)
    watcher.unwatch
  end
end
```

This interface is what's required to make redis-clustering/redis-rb work correctly, I think.