### PR TITLE
Add an explicit #watch method to RedisClient::Cluster

### DIFF
--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -461,11 +461,13 @@ class RedisClient
       def test_transaction_with_dedicated_watch_command
         @client.call('MSET', '{key}1', '0', '{key}2', '0')
 
-        got = @client.call('WATCH', '{key}1', '{key}2') do |tx|
-          tx.call('ECHO', 'START')
-          tx.call('SET', '{key}1', '1')
-          tx.call('SET', '{key}2', '2')
-          tx.call('ECHO', 'FINISH')
+        got = @client.send(:watch, ['{key}1', '{key}2']) do |watcher|
+          watcher.multi do |tx|
+            tx.call('ECHO', 'START')
+            tx.call('SET', '{key}1', '1')
+            tx.call('SET', '{key}2', '2')
+            tx.call('ECHO', 'FINISH')
+          end
         end
 
         assert_equal(%w[START OK OK FINISH], got)
@@ -473,8 +475,8 @@ class RedisClient
       end
 
       def test_transaction_with_dedicated_watch_command_without_block
-        assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
-          @client.call('WATCH', '{key}1', '{key}2')
+        assert_raises(ArgumentError) do
+          @client.send(:watch, ['{key}1', '{key}2'])
         end
       end
 


### PR DESCRIPTION
(this is a continuation of https://github.com/redis-rb/redis-cluster-client/pull/339 )

----

This returns a "watcher" object, which can either be used for three things:

* To add keys to be watched on the same connection (by calling #watch
* To begin a MULTI transaction on the connection (by calling #multi)
* To UNWATCH the connection and return it to its original state (by calling... #unwatch)

This means that the following pattern becomes possible in redis-cluster-client:

```
client.watch(["{slot}k1", "{slot}k2"]) do |watcher|
  # Further reads can be performed with client directly; this is
  # perfectly safe and they will be individually redirected if required
  # as normal.
  # If a read on a slot being watched is redirected, that's also OK,
  # because it means the final EXEC will fail (since the watch got
  # modified).
  current_value = client.call('GET', '{slot}k1')
  some_other_thing = client.call('GET', '{slot}something_unwatched')

  # You can add more keys to the watch if required
  # This could raise a redireciton error, and cause the whole watch
  # block to be re-attempted
  watcher.watch('{slot}differet_key')
  different_value = client.call('GET', '{slot}different_key')

  if do_transaction?
    # Once you're ready to perform a transaction, you can use multi...
    watcher.multi do |tx|
      # tx is now a pipeliend RedisClient::Cluster::Transaction
      # instance, like normal multi
      tx.call('SET', '{slot}k1', 'new_value')
      tx.call('SET', '{slot}k2', 'new_value')
    end
    # At this point, the transaction is committed
  else
    # You can abort the transaction by calling unwatch
    # (this will also happen if an exception is thrown)
    watcher.unwatch
  end
end
```

This interface is what's required to make redis-clustering/redis-rb work correctly, I think.