### PR TITLE
test: fix a error handling bug

### DIFF
--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -146,7 +146,7 @@ class ClusterController
     ([dest, src] + rest).each do |cli|
       cli.call('CLUSTER', 'SETSLOT', slot, 'NODE', id)
     rescue ::RedisClient::CommandError => e
-      raise if e.message != 'ERR Please use SETSLOT only with masters.'
+      raise unless e.message.start_with?('ERR Please use SETSLOT only with masters.')
       # how weird, ignore
     end
 


### PR DESCRIPTION
```
TestAgainstClusterScale#test_02_scale_in:
RedisClient::CommandError: ERR Please use SETSLOT only with masters. (redis://127.0.0.1:6385)
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client/connection_mixin.rb:36:in `call'
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client.rb:279:in `block (2 levels) in call'
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client/middlewares.rb:16:in `call'
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client.rb:278:in `block in call'
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client.rb:699:in `ensure_connected'
    vendor/bundle/ruby/3.3.0/gems/redis-client-0.21.0/lib/redis_client.rb:277:in `call'
    test/cluster_controller.rb:147:in `block in finish_resharding'
```

Although it's a bad way of the error handling.