### PR TITLE
fix: make the error identification middleware optional because of the use case

### DIFF
--- a/lib/redis_client/cluster/error_identification.rb
+++ b/lib/redis_client/cluster/error_identification.rb
@@ -4,7 +4,13 @@ class RedisClient
   class Cluster
     module ErrorIdentification
       def self.client_owns_error?(err, client)
-        err.is_a?(TaggedError) && err.from?(client)
+        return true unless identifiable?(err)
+
+        err.from?(client)
+      end
+
+      def self.identifiable?(err)
+        err.is_a?(TaggedError)
       end
 
       module TaggedError

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -2,7 +2,6 @@
 
 require 'redis_client'
 require 'redis_client/config'
-require 'redis_client/cluster/error_identification'
 require 'redis_client/cluster/errors'
 require 'redis_client/cluster/node/primary_only'
 require 'redis_client/cluster/node/random_replica'
@@ -79,11 +78,9 @@ class RedisClient
       end
 
       class Config < ::RedisClient::Config
-        def initialize(scale_read: false, middlewares: nil, **kwargs)
+        def initialize(scale_read: false, **kwargs)
           @scale_read = scale_read
-          middlewares ||= []
-          middlewares.unshift ErrorIdentification::Middleware
-          super(middlewares: middlewares, **kwargs)
+          super(**kwargs)
         end
 
         private
@@ -215,10 +212,6 @@ class RedisClient
             @topology.process_topology_update!(@replications, @node_configs)
           end
         end
-      end
-
-      def owns_error?(err)
-        any? { |c| ErrorIdentification.client_owns_error?(err, c) }
       end
 
       private

--- a/test/redirection_emulation_middleware.rb
+++ b/test/redirection_emulation_middleware.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RedirectionEmulationMiddleware
+  def call(cmd, cfg)
+    r = cfg.custom[:redirect]
+    raise RedisClient::CommandError, "MOVED #{r[:slot]} #{r[:to]}" if cmd == r[:command]
+
+    super
+  end
+
+  def call_pipelined(cmd, cfg)
+    r = cfg.custom[:redirect]
+    raise RedisClient::CommandError, "MOVED #{r[:slot]} #{r[:to]}" if cmd == r[:command]
+
+    super
+  end
+end

--- a/test/redirection_emulation_middleware.rb
+++ b/test/redirection_emulation_middleware.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
 module RedirectionEmulationMiddleware
+  Setting = Struct.new(
+    'RedirectionEmulationMiddlewareSetting',
+    :slot, :to, :command, keyword_init: true
+  )
+
   def call(cmd, cfg)
-    r = cfg.custom[:redirect]
-    raise RedisClient::CommandError, "MOVED #{r[:slot]} #{r[:to]}" if cmd == r[:command]
+    s = cfg.custom.fetch(:redirect)
+    raise RedisClient::CommandError, "MOVED #{s.slot} #{s.to}" if cmd == s.command
 
     super
   end
 
   def call_pipelined(cmd, cfg)
-    r = cfg.custom[:redirect]
-    raise RedisClient::CommandError, "MOVED #{r[:slot]} #{r[:to]}" if cmd == r[:command]
+    s = cfg.custom.fetch(:redirect)
+    raise RedisClient::CommandError, "MOVED #{s.slot} #{s.to}" if cmd == s.command
 
     super
   end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -726,11 +726,20 @@ class RedisClient
           middlewares: [::RedisClient::Cluster::ErrorIdentification::Middleware]
         )
 
+        middlewares = [
+          ::RedisClient::Cluster::ErrorIdentification::Middleware,
+          RedirectionEmulationMiddleware
+        ]
+
+        if RUBY_ENGINE == 'ruby'
+          major, minor, = RUBY_VERSION.split('.')
+          major = Integer(major)
+          minor = Integer(minor)
+          middlewares.reverse! if major < 3 || (major >= 3 && minor < 1)
+        end
+
         client2 = new_test_client(
-          middlewares: [
-            ::RedisClient::Cluster::ErrorIdentification::Middleware,
-            RedirectionEmulationMiddleware
-          ],
+          middlewares: middlewares,
           custom: { redirect: { slot: slot, to: broken_primary_key, command: %w[GET testkey] } }
         )
 

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -814,7 +814,7 @@ class RedisClient
         config = ::RedisClient::ClusterConfig.new(
           nodes: TEST_NODE_URIS,
           fixed_hostname: TEST_FIXED_HOSTNAME,
-          middlewares: [CommandCaptureMiddleware],
+          middlewares: [CommandCaptureMiddleware, ::RedisClient::Cluster::ErrorIdentification::Middleware],
           custom: { captured_commands: capture_buffer },
           **TEST_GENERIC_OPTIONS,
           **opts
@@ -832,7 +832,7 @@ class RedisClient
           replica: true,
           replica_affinity: :random,
           fixed_hostname: TEST_FIXED_HOSTNAME,
-          middlewares: [CommandCaptureMiddleware],
+          middlewares: [CommandCaptureMiddleware, ::RedisClient::Cluster::ErrorIdentification::Middleware],
           custom: { captured_commands: capture_buffer },
           **TEST_GENERIC_OPTIONS,
           **opts
@@ -850,7 +850,7 @@ class RedisClient
           replica: true,
           replica_affinity: :random_with_primary,
           fixed_hostname: TEST_FIXED_HOSTNAME,
-          middlewares: [CommandCaptureMiddleware],
+          middlewares: [CommandCaptureMiddleware, ::RedisClient::Cluster::ErrorIdentification::Middleware],
           custom: { captured_commands: capture_buffer },
           **TEST_GENERIC_OPTIONS,
           **opts
@@ -868,7 +868,7 @@ class RedisClient
           replica: true,
           replica_affinity: :latency,
           fixed_hostname: TEST_FIXED_HOSTNAME,
-          middlewares: [CommandCaptureMiddleware],
+          middlewares: [CommandCaptureMiddleware, ::RedisClient::Cluster::ErrorIdentification::Middleware],
           custom: { captured_commands: capture_buffer },
           **TEST_GENERIC_OPTIONS,
           **opts
@@ -884,7 +884,7 @@ class RedisClient
         config = ::RedisClient::ClusterConfig.new(
           nodes: TEST_NODE_URIS,
           fixed_hostname: TEST_FIXED_HOSTNAME,
-          middlewares: [CommandCaptureMiddleware],
+          middlewares: [CommandCaptureMiddleware, ::RedisClient::Cluster::ErrorIdentification::Middleware],
           custom: { captured_commands: capture_buffer },
           **TEST_GENERIC_OPTIONS,
           **opts

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -753,12 +753,12 @@ class RedisClient
           RedirectionEmulationMiddleware
         ]
 
-        if RUBY_ENGINE == 'ruby'
-          major, minor, = RUBY_VERSION.split('.')
-          major = Integer(major)
-          minor = Integer(minor)
-          middlewares.reverse! if major < 3 || (major >= 3 && minor < 1)
-        end
+        # if RUBY_ENGINE == 'ruby'
+        #   major, minor, = RUBY_VERSION.split('.')
+        #   major = Integer(major)
+        #   minor = Integer(minor)
+        #   middlewares.reverse! if major < 3 || (major >= 3 && minor < 1)
+        # end
 
         client2 = new_test_client(
           middlewares: middlewares,

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -7,6 +7,7 @@ require 'redis-cluster-client'
 require 'testing_constants'
 require 'cluster_controller'
 require 'command_capture_middleware'
+require 'redirection_emulation_middleware'
 
 case ENV.fetch('REDIS_CONNECTION_DRIVER', 'ruby')
 when 'hiredis' then require 'hiredis-client'


### PR DESCRIPTION
* #310
* I doubt whether every user needs the error identification middleware or not. I think our 99% users don't use this library in a nested block against multiple clusters. Also, middlewares are called every time by commands and pipelines. It affects the performance in no small measure.
* The node class doesn't need any dependencies with the middleware. So we should decouple them. The middleware is used by only the router class.