### PR TITLE
fix: a not initialized instance variable warned on Ruby 2.7

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -106,6 +106,7 @@ class RedisClient
         @topology = klass.new(pool, @concurrent_worker, **kwargs)
         @config = config
         @mutex = Mutex.new
+        @last_reloaded_at = nil
       end
 
       def inspect


### PR DESCRIPTION
> /home/runner/work/redis-cluster-client/redis-cluster-client/lib/redis_client/cluster/node.rb:427: warning: instance variable @last_reloaded_at not initialized