### PR TITLE
fix: return empty array if the transaction is empty

### DIFF
--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -224,9 +224,20 @@ class RedisClient
         end
       end
 
-      def test_transaction_with_empty_block
-        assert_raises(ArgumentError) { @client.multi {} }
+      def test_transaction_without_block
         assert_raises(LocalJumpError) { @client.multi }
+      end
+
+      def test_transaction_with_empty_block
+        @captured_commands.clear
+        assert_empty(@client.multi {})
+        assert_empty(@captured_commands.to_a.map(&:command).map(&:first))
+      end
+
+      def test_transaction_with_empty_block_and_watch
+        @captured_commands.clear
+        assert_empty(@client.multi(watch: %w[key]) {})
+        assert_equal(%w[WATCH MULTI EXEC], @captured_commands.to_a.map(&:command).map(&:first))
       end
 
       def test_transaction_with_only_keyless_commands


### PR DESCRIPTION
It  should be behaved as the same as redis-client.
https://github.com/redis-rb/redis-client/blob/d895cf32ffe779d2c6692e1006947ed9c0eb63a0/lib/redis_client.rb#L445-L477