### PR TITLE
Assign a new node after calling update_cluster_info!

### DIFF
--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -58,6 +58,8 @@ class ClusterController
     @debug = ENV.fetch('DEBUG', '0')
   end
 
+  attr_reader :clients
+
   def wait_for_cluster_to_be_ready(skip_clients: [])
     print_debug('wait for nodes to be recognized...')
     wait_meeting(@clients, max_attempts: @max_attempts)

--- a/test/test_against_cluster_broken.rb
+++ b/test/test_against_cluster_broken.rb
@@ -3,6 +3,7 @@
 require 'logger'
 require 'json'
 require 'testing_helper'
+require 'securerandom'
 
 class TestAgainstClusterBroken < TestingWrapper
   WAIT_SEC = 0.1
@@ -52,6 +53,41 @@ class TestAgainstClusterBroken < TestingWrapper
     revive_dead_nodes
     wait_for_cluster_to_be_ready
     do_assertions(offset: 3)
+  end
+
+  def test_reloading_on_connection_error
+    sacrifice = @controller.select_sacrifice_of_primary
+    # Find a key which lives on the sacrifice node
+    test_key = generate_key_for_node(sacrifice)
+    @clients[0].call('SET', test_key, 'foobar1')
+
+    # Shut the node down.
+    kill_a_node_and_wait_for_failover(sacrifice)
+
+    # When we try and fetch the key, it'll attempt to connect to the broken node, and
+    # thus trigger a reload of the cluster topology.
+    assert_equal 'OK', @clients[0].call('SET', test_key, 'foobar2')
+  end
+
+  def test_transaction_retry_on_connection_error
+    sacrifice = @controller.select_sacrifice_of_primary
+    # Find a key which lives on the sacrifice node
+    test_key = generate_key_for_node(sacrifice)
+    @clients[0].call('SET', test_key, 'foobar1')
+
+    call_count = 0
+    # Begin a transaction, but shut the node down after the WATCH is issued
+    res = @clients[0].multi(watch: [test_key]) do |tx|
+      kill_a_node_and_wait_for_failover(sacrifice) if call_count == 0
+      call_count += 1
+      tx.call('SET', test_key, 'foobar2')
+    end
+
+    # The transaction should have retried once and successfully completed
+    # the second time.
+    assert_equal ['OK'], res
+    assert_equal 'foobar2', @clients[0].call('GET', test_key)
+    assert_equal 2, call_count
   end
 
   private
@@ -126,6 +162,18 @@ class TestAgainstClusterBroken < TestingWrapper
       end
 
       log_metrics
+    end
+  end
+
+  def generate_key_for_node(conn)
+    # Figure out a slot on the the sacrifice node, and a key in that slot.
+    conn_id = conn.call('CLUSTER', 'MYID')
+    conn_slots = conn.call('CLUSTER', 'SLOTS')
+                     .select { |res| res[2][2] == conn_id }
+                     .flat_map { |res| (res[0]..res[1]).to_a }
+    loop do
+      test_key = SecureRandom.hex
+      return test_key if conn_slots.include?(conn.call('CLUSTER', 'KEYSLOT', test_key))
     end
   end
 
@@ -208,6 +256,23 @@ class TestAgainstClusterBroken < TestingWrapper
 
       @cluster_down_error_count += 1
       sleep wait_sec
+    end
+  end
+
+  def kill_a_node_and_wait_for_failover(sacrifice)
+    other_client = @controller.clients.reject { _1 == sacrifice }.first
+    sacrifice_id = sacrifice.call('CLUSTER', 'MYID')
+    kill_a_node(sacrifice)
+    failover_checks = 0
+    loop do
+      raise 'Timed out waiting for failover in kill_a_node_and_wait_for_failover' if failover_checks > 30
+
+      # Wait for the sacrifice node to not be a primary according to CLUSTER SLOTS.
+      cluster_slots = other_client.call('CLUSTER', 'SLOTS')
+      break unless cluster_slots.any? { _1[2][2] == sacrifice_id }
+
+      sleep 1
+      failover_checks += 1
     end
   end
 


### PR DESCRIPTION
If we catch a connection error and refresh the cluster topology, we need to re-calculate what node to send the command to in the router; the node we're using might not even be a valid node any longer.

I added two test cases to test_against_cluster_broken.rb which demonstrate this; one with a transaction, and one without. In both cases, without the patch, the first command after a node goes down fails because the client realises it needs to fetch new node info (with `update_cluster_info!`), but then retries the command on the old node still (which doesn't even exist anymore). The patch fixes this.

Unfortunately these tests won't pass on CI at the moment because of #354 but they work on my machine if you run them by themseles (with `bundle exec ruby -Itest test/test_against_cluster_broken.rb -n 'test_reloading_on_connection_error'`).