### PR TITLE
feat: prevent a cross slot error by using pipelining when calling a command with multiple keys

### DIFF
--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -97,6 +97,12 @@ class RedisClient
         @commands.key?(::RedisClient::Cluster::NormalizedCmdName.instance.get_by_name(name))
       end
 
+      def determine_key_step(command)
+        name = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
+        # Some commands like EVALSHA have zero as the step in COMMANDS somehow.
+        @commands[name].key_step == 0 ? 1 : @commands[name].key_step
+      end
+
       private
 
       def determine_first_key_position(command) # rubocop:disable Metrics/CyclomaticComplexity
@@ -141,12 +147,6 @@ class RedisClient
             command.length + @commands[name].last_key_position
           end
         end
-      end
-
-      def determine_key_step(command)
-        name = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
-        # Some commands like EVALSHA have zero as the step in COMMANDS somehow.
-        @commands[name].key_step == 0 ? 1 : @commands[name].key_step
       end
 
       def determine_optional_key_position(command, option_name) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -147,6 +147,20 @@ class RedisClient
         end
       end
 
+      def test_determine_key_step
+        cmd = ::RedisClient::Cluster::Command.load(@raw_clients)
+        [
+          { name: 'MSET', want: 2 },
+          { name: 'MGET', want: 1 },
+          { name: 'DEL', want: 1 },
+          { name: 'EVALSHA', want: 1 }
+        ].each_with_index do |c, idx|
+          msg = "Case: #{idx}"
+          got = cmd.determine_key_step(c[:name])
+          assert_equal(c[:want], got, msg)
+        end
+      end
+
       def test_determine_first_key_position
         cmd = ::RedisClient::Cluster::Command.load(@raw_clients)
         [


### PR DESCRIPTION
It might be useful. Although there may be more, we are going to support `MSET`, `MGET` and `DEL` so far.