### PR TITLE
perf: lessen memory consumption for emulated mget command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -246,6 +246,8 @@ jobs:
           - single
           - excessive_pipelining
           - pipelining_in_moderation
+          - original_mget
+          - emulated_mget
     env:
       REDIS_VERSION: '7.2'
       DOCKER_COMPOSE_FILE: 'compose.yaml'

--- a/test/ips_mget.rb
+++ b/test/ips_mget.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'redis_cluster_client'
+require 'testing_constants'
+
+module IpsMget
+  module_function
+
+  ATTEMPTS = 40
+
+  def run
+    cli = make_client
+    prepare(cli)
+    print_letter('MGET')
+    bench('MGET', cli)
+  end
+
+  def make_client
+    ::RedisClient.cluster(
+      nodes: TEST_NODE_URIS,
+      replica: true,
+      replica_affinity: :random,
+      fixed_hostname: TEST_FIXED_HOSTNAME,
+      concurrency: { model: :on_demand },
+      **TEST_GENERIC_OPTIONS
+    ).new_client
+  end
+
+  def print_letter(title)
+    print "################################################################################\n"
+    print "# #{title}\n"
+    print "################################################################################\n"
+    print "\n"
+  end
+
+  def prepare(client)
+    ATTEMPTS.times do |i|
+      client.call('SET', "{key}#{i}", "val#{i}")
+      client.call('SET', "key#{i}", "val#{i}")
+    end
+  end
+
+  def bench(cmd, client)
+    original = [cmd] + Array.new(ATTEMPTS) { |i| "{key}#{i}" }
+    emulated = [cmd] + Array.new(ATTEMPTS) { |i| "key#{i}" }
+
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+      x.report("#{cmd}: original") { client.call_v(original) }
+      x.report("#{cmd}: emulated") { client.call_v(emulated) }
+      x.compare!
+    end
+  end
+end
+
+IpsMget.run

--- a/test/prof_mem.rb
+++ b/test/prof_mem.rb
@@ -10,6 +10,8 @@ module ProfMem
   ATTEMPT_COUNT = 1000
   MAX_PIPELINE_SIZE = 100
   SLICED_NUMBERS = (1..ATTEMPT_COUNT).each_slice(MAX_PIPELINE_SIZE).freeze
+  ORIGINAL_MGET = (%w[MGET] + Array.new(40) { |i| "{key}#{i}" }).freeze
+  EMULATED_MGET = (%w[MGET] + Array.new(40) { |i| "key#{i}" }).freeze
   CLI_TYPES = %w[primary_only scale_read_random scale_read_latency pooled].freeze
   MODES = {
     single: lambda do |client_builder_method|
@@ -38,6 +40,14 @@ module ProfMem
           numbers.each { |i| pi.call('GET', i) }
         end
       end
+    end,
+    original_mget: lambda do |client_builder_method|
+      cli = send(client_builder_method)
+      ATTEMPT_COUNT.times { cli.call_v(ORIGINAL_MGET) }
+    end,
+    emulated_mget: lambda do |client_builder_method|
+      cli = send(client_builder_method)
+      ATTEMPT_COUNT.times { cli.call_v(EMULATED_MGET) }
     end
   }.freeze
 

--- a/test/prof_stack.rb
+++ b/test/prof_stack.rb
@@ -9,6 +9,8 @@ require 'testing_constants'
 module ProfStack
   SIZE = 40
   ATTEMPTS = 1000
+  ORIGINAL_MGET = (%w[MGET] + Array.new(SIZE) { |i| "{key}#{i}" }).freeze
+  EMULATED_MGET = (%w[MGET] + Array.new(SIZE) { |i| "key#{i}" }).freeze
 
   module_function
 
@@ -36,6 +38,7 @@ module ProfStack
         SIZE.times do |j|
           n = SIZE * i + j
           pi.call('SET', "key#{n}", "val#{n}")
+          pi.call('SET', "{key}#{n}", "val#{n}")
         end
       end
     end
@@ -58,6 +61,10 @@ module ProfStack
           end
         end
       end
+    when :original_mget
+      ATTEMPTS.times { client.call_v(ORIGINAL_MGET) }
+    when :emulated_mget
+      ATTEMPTS.times { client.call_v(EMULATED_MGET) }
     else raise ArgumentError, mode
     end
   end


### PR DESCRIPTION
* #356

## Before
```
allocated memory by gem
-----------------------------------
  14959968  redis-client-0.22.1
  14496373  redis-cluster-client/lib
    120832  other
     80439  socket
     11472  uri
```

## After
```
allocated memory by gem
-----------------------------------
  13359968  redis-client-0.22.1
   6496373  redis-cluster-client/lib
    120832  other
     63891  socket
     11472  uri
```

## But
```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
Warming up --------------------------------------
      MGET: original   313.000 i/100ms
      MGET: emulated    54.000 i/100ms
Calculating -------------------------------------
      MGET: original      3.083k (±10.0%) i/s -     15.337k in   5.049041s
      MGET: emulated    521.688 (± 8.8%) i/s -      2.592k in   5.013249s

Comparison:
      MGET: original:     3083.2 i/s
      MGET: emulated:      521.7 i/s - 5.91x  slower
```