### PR TITLE
ci: add a case to the test for the iteration per second

### DIFF
--- a/test/ips_mget.rb
+++ b/test/ips_mget.rb
@@ -44,12 +44,21 @@ module IpsMget
   def bench(cmd, client)
     original = [cmd] + Array.new(ATTEMPTS) { |i| "{key}#{i}" }
     emulated = [cmd] + Array.new(ATTEMPTS) { |i| "key#{i}" }
+    single_get = [cmd]
 
     Benchmark.ips do |x|
       x.time = 5
       x.warmup = 1
       x.report("#{cmd}: original") { client.call_v(original) }
       x.report("#{cmd}: emulated") { client.call_v(emulated) }
+
+      x.report("#{cmd}: single_get") do
+        ATTEMPTS.times do |i|
+          single_get[1] = "key#{i}"
+          client.call_v(single_get)
+        end
+      end
+
       x.compare!
     end
   end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -364,7 +364,10 @@ class RedisClient
           tx.call('SET', '{key}1', '1')
           tx.call('SET', '{key}2', '2')
         end
+
         assert_equal(%w[WATCH MULTI SET SET EXEC], @captured_commands.to_a.map(&:command).map(&:first))
+
+        wait_for_replication
         assert_equal(%w[1 2], @client.call('MGET', '{key}1', '{key}2'))
       end
 


### PR DESCRIPTION
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
Warming up --------------------------------------
      MGET: original   670.000 i/100ms
      MGET: emulated    99.000 i/100ms
    MGET: single_get    30.000 i/100ms
Calculating -------------------------------------
      MGET: original      6.880k (± 6.7%) i/s -     34.840k in   5.093497s
      MGET: emulated    984.077 (± 6.1%) i/s -      4.950k in   5.057650s
    MGET: single_get    317.817 (± 4.4%) i/s -      1.590k in   5.012359s

Comparison:
      MGET: original:     6880.2 i/s
      MGET: emulated:      984.1 i/s - 6.99x  slower
    MGET: single_get:      317.8 i/s - 21.65x  slower
```