### PR TITLE
perf: lessen memory consumptions in a emulated mget method

### DIFF
--- a/lib/redis_client/cluster/key_slot_converter.rb
+++ b/lib/redis_client/cluster/key_slot_converter.rb
@@ -70,6 +70,17 @@ class RedisClient
 
         key[s + 1..e - 1]
       end
+
+      def hash_tag_included?(key)
+        key = key.to_s
+        s = key.index(LEFT_BRACKET)
+        return false if s.nil?
+
+        e = key.index(RIGHT_BRACKET, s + 1)
+        return false if e.nil?
+
+        s + 1 < e
+      end
     end
   end
 end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -336,7 +336,7 @@ class RedisClient
 
       def send_multiple_keys_command(cmd, method, command, args, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         key_step = @command.determine_key_step(cmd)
-        if command.size <= key_step + 1 || !::RedisClient::Cluster::KeySlotConverter.extract_hash_tag(command[1]).empty? # rubocop:disable Style/IfUnlessModifier
+        if command.size <= key_step + 1 || ::RedisClient::Cluster::KeySlotConverter.hash_tag_included?(command[1]) # rubocop:disable Style/IfUnlessModifier
           return try_send(assign_node(command), method, command, args, &block)
         end
 

--- a/test/redis_client/cluster/test_key_slot_converter.rb
+++ b/test/redis_client/cluster/test_key_slot_converter.rb
@@ -48,6 +48,27 @@ class RedisClient
           assert_equal(c[:want], got, msg)
         end
       end
+
+      def test_hash_tag_included?
+        [
+          { key: 'foo', want: false },
+          { key: 'foo{bar}baz', want: true },
+          { key: 'foo{bar}baz{qux}quuc', want: true },
+          { key: 'foo}bar{baz', want: false },
+          { key: 'foo{bar', want: false },
+          { key: 'foo}bar', want: false },
+          { key: 'foo{}bar', want: false },
+          { key: '{}foo', want: false },
+          { key: 'foo{}', want: false },
+          { key: '{}', want: false },
+          { key: '', want: false },
+          { key: nil, want: false }
+        ].each_with_index do |c, idx|
+          msg = "Case: #{idx}"
+          got = ::RedisClient::Cluster::KeySlotConverter.hash_tag_included?(c[:key])
+          assert_equal(c[:want], got, msg)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Before

```
allocated memory by gem
-----------------------------------
   5506464  redis-client-0.22.1
    435368  redis-cluster-client/lib
     70110  socket
     10672  uri
      1072  other
```

```
allocated memory by location
-----------------------------------
   1640720  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:99
   1027840  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:54
    976160  redis-client-0.22.1/lib/redis_client/command_builder.rb:9
    788688  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:189
    488440  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:38
    187440  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:32
    175840  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:175
    160000  redis-cluster-client/lib/redis_client/cluster/key_slot_converter.rb:71
    146440  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:39
     75160  redis-cluster-client/lib/redis_client/cluster/command.rb:53
     66512  redis-cluster-client/lib/redis_client/cluster/node.rb:53
     57918  ruby/lib/socket.rb:457
     40440  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:69
     40000  redis-cluster-client/lib/redis_client/cluster.rb:34
     16548  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:18
     11520  redis-cluster-client/lib/redis_client/cluster/node.rb:346
     11232  redis-cluster-client/lib/redis_client/cluster/node.rb:359
      9920  ruby/lib/socket.rb:231
      7328  redis-cluster-client/lib/redis_client/cluster/command.rb:50
      7208  redis-cluster-client/lib/redis_client/cluster/node/base_topology.rb:55
```

## After

```
allocated memory by gem
-----------------------------------
   5541520  redis-client-0.22.1
    355368  redis-cluster-client/lib
     77295  socket
     10672  uri
      1072  other
```

```
allocated memory by location
-----------------------------------
   1640800  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:99
   1028320  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:54
    976160  redis-client-0.22.1/lib/redis_client/command_builder.rb:9
    788728  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:189
    488480  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:38
    187520  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:32
    176000  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:175
    146880  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:39
     80000  redis-cluster-client/lib/redis_client/cluster/key_slot_converter.rb:71
     75160  redis-cluster-client/lib/redis_client/cluster/command.rb:53
     66512  redis-cluster-client/lib/redis_client/cluster/node.rb:53
     62055  ruby/lib/socket.rb:457
     49364  redis-client-0.22.1/lib/redis_client/ruby_connection/buffered_io.rb:18
     40480  redis-client-0.22.1/lib/redis_client/ruby_connection/resp3.rb:69
     40000  redis-cluster-client/lib/redis_client/cluster.rb:34
     12400  ruby/lib/socket.rb:231
     11520  redis-cluster-client/lib/redis_client/cluster/node.rb:346
     11232  redis-cluster-client/lib/redis_client/cluster/node.rb:359
      7328  redis-cluster-client/lib/redis_client/cluster/command.rb:50
      7208  redis-cluster-client/lib/redis_client/cluster/node/base_topology.rb:55
```