### PR TITLE
chore: add a ruby container to docker compose for macOS users

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -65,3 +65,22 @@ services:
         condition: service_healthy
       node6:
         condition: service_healthy
+  ruby:
+    image: "ruby:${RUBY_VERSION:-3}"
+    restart: always
+    working_dir: /client
+    volumes:
+      - .:/client
+    command:
+      - ruby
+      - "-e"
+      - 'Signal.trap(:INT, "EXIT"); Signal.trap(:TERM, "EXIT"); loop { sleep 1 }'
+    environment:
+      REDIS_HOST: node1
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "ruby", "-e", "'puts 1'"]
+      interval: "5s"
+      timeout: "3s"
+      retries: 3


### PR DESCRIPTION
* #89
* #354

```
$ docker compose up
$ docker compose exec ruby bundle install
$ docker compose exec ruby bundle exec rake test
```

This is just an workaround. I'd like to improve the test environment to be simple and easy to use for everyone in the future. I think the current setting is complex and awkward.