### PR TITLE
ci: shorten blocking timeout seconds, add a test case for Valkey

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         include:
           - {redis: '7.2', ruby: '3.3'}
+          - {redis: '7.2', ruby: '3.3', compose: compose.valkey.yaml}
           - {redis: '7.2', ruby: '3.3', compose: compose.ssl.yaml}
           - {redis: '7.2', ruby: '3.3', driver: 'hiredis'}
           - {redis: '7.2', ruby: '3.3', driver: 'hiredis', compose: compose.ssl.yaml}
@@ -60,7 +61,7 @@ jobs:
           ruby-version: ${{ matrix.ruby || '3.3' }}
           bundler-cache: true
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
       - name: Wait for Redis cluster to be ready

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
           host_ip_addr=$(ip a | grep eth0 | grep inet | awk '{print $2}' | cut -d'/' -f1)
           echo "HOST_IP_ADDR=$host_ip_addr" >> $GITHUB_ENV
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
         env:
@@ -163,7 +163,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
       - name: Wait for Redis cluster to be ready
@@ -223,7 +223,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
       - name: Wait for Redis cluster to be ready
@@ -261,7 +261,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
       - name: Wait for Redis cluster to be ready
@@ -317,7 +317,7 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_max_syn_backlog=1024 # backlog setting
           sudo sysctl -w net.core.somaxconn=1024           # up the number of connections per port
       - name: Pull Docker images
-        run: docker pull redis:$REDIS_VERSION
+        run: docker compose -f $DOCKER_COMPOSE_FILE pull
       - name: Run containers
         run: docker compose -f $DOCKER_COMPOSE_FILE up -d
       - name: Print memory info

--- a/compose.valkey.yaml
+++ b/compose.valkey.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   node1: &node
-    image: "valkey/valkey:${VALKEY_VERSION:-7}"
+    image: "valkey/valkey:${REDIS_VERSION:-7}"
     command: >
       valkey-server
       --maxmemory            64mb
@@ -39,7 +39,7 @@ services:
     ports:
       - "6384:6379"
   clustering:
-    image: "valkey/valkey:${VALKEY_VERSION:-7}"
+    image: "valkey/valkey:${REDIS_VERSION:-7}"
     command: >
       bash -c "apt-get update > /dev/null
       && apt-get install --no-install-recommends --no-install-suggests -y dnsutils > /dev/null

--- a/compose.valkey.yaml
+++ b/compose.valkey.yaml
@@ -1,0 +1,86 @@
+---
+services:
+  node1: &node
+    image: "valkey/valkey:${VALKEY_VERSION:-7}"
+    command: >
+      valkey-server
+      --maxmemory            64mb
+      --maxmemory-policy     allkeys-lru
+      --appendonly           yes
+      --cluster-enabled      yes
+      --cluster-config-file  nodes.conf
+      --cluster-node-timeout 5000
+    restart: "${RESTART_POLICY:-always}"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: "7s"
+      timeout: "5s"
+      retries: 10
+    ports:
+      - "6379:6379"
+  node2:
+    <<: *node
+    ports:
+      - "6380:6379"
+  node3:
+    <<: *node
+    ports:
+      - "6381:6379"
+  node4:
+    <<: *node
+    ports:
+      - "6382:6379"
+  node5:
+    <<: *node
+    ports:
+      - "6383:6379"
+  node6:
+    <<: *node
+    ports:
+      - "6384:6379"
+  clustering:
+    image: "valkey/valkey:${VALKEY_VERSION:-7}"
+    command: >
+      bash -c "apt-get update > /dev/null
+      && apt-get install --no-install-recommends --no-install-suggests -y dnsutils > /dev/null
+      && rm -rf /var/lib/apt/lists/*
+      && yes yes | valkey-cli --cluster create
+      $$(dig node1 +short):6379
+      $$(dig node2 +short):6379
+      $$(dig node3 +short):6379
+      $$(dig node4 +short):6379
+      $$(dig node5 +short):6379
+      $$(dig node6 +short):6379
+      --cluster-replicas 1"
+    depends_on:
+      node1:
+        condition: service_healthy
+      node2:
+        condition: service_healthy
+      node3:
+        condition: service_healthy
+      node4:
+        condition: service_healthy
+      node5:
+        condition: service_healthy
+      node6:
+        condition: service_healthy
+  ruby:
+    image: "ruby:${RUBY_VERSION:-3}"
+    restart: always
+    working_dir: /client
+    volumes:
+      - .:/client
+    command:
+      - ruby
+      - "-e"
+      - 'Signal.trap(:INT, "EXIT"); Signal.trap(:TERM, "EXIT"); loop { sleep 1 }'
+    environment:
+      REDIS_HOST: node1
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "ruby", "-e", "'puts 1'"]
+      interval: "5s"
+      timeout: "3s"
+      retries: 3

--- a/test/benchmark_helper.rb
+++ b/test/benchmark_helper.rb
@@ -11,4 +11,24 @@ case ENV.fetch('REDIS_CONNECTION_DRIVER', 'ruby')
 when 'hiredis' then require 'hiredis-client'
 end
 
-class BenchmarkWrapper < Minitest::Benchmark; end
+class BenchmarkWrapper < Minitest::Benchmark
+  private
+
+  def swap_timeout(client, timeout:)
+    return if client.nil?
+
+    node = client.instance_variable_get(:@router)&.instance_variable_get(:@node)
+    raise 'The client must be initialized.' if node.nil?
+
+    updater = lambda do |c, t|
+      c.read_timeout = t
+      c.config.instance_variable_set(:@read_timeout, t)
+    end
+
+    regular_timeout = node.first.read_timeout
+    node.each { |cli| updater.call(cli, timeout) }
+    result = yield client
+    node.each { |cli| updater.call(cli, regular_timeout) }
+    result
+  end
+end

--- a/test/benchmark_mixin.rb
+++ b/test/benchmark_mixin.rb
@@ -81,7 +81,9 @@ module BenchmarkMixin
   def wait_for_replication
     client_side_timeout = TEST_TIMEOUT_SEC + 1.0
     server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-    @client&.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    swap_timeout(@client, timeout: 0.1) do |client|
+      client&.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    end
   end
 end
 
@@ -109,6 +111,8 @@ module BenchmarkMixinForProxy
   def wait_for_replication
     client_side_timeout = TEST_TIMEOUT_SEC + 1.0
     server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-    @cluster_client&.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    swap_timeout(@cluster_client, timeout: 0.1) do |cluster_client|
+      cluster_client&.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    end
   end
 end

--- a/test/test_against_cluster_broken.rb
+++ b/test/test_against_cluster_broken.rb
@@ -40,7 +40,9 @@ class TestAgainstClusterBroken < TestingWrapper
   def wait_for_replication
     client_side_timeout = TEST_TIMEOUT_SEC + 1.0
     server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-    @client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    swap_timeout(@client, timeout: 0.1) do |client|
+      client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    end
   end
 
   def do_test_a_node_is_down(sacrifice, number_of_keys:)

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -71,7 +71,9 @@ class TestAgainstClusterScale < TestingWrapper
   def wait_for_replication
     client_side_timeout = TEST_TIMEOUT_SEC + 1.0
     server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-    @client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    swap_timeout(@client, timeout: 0.1) do |client|
+      client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+    end
   end
 
   def build_cluster_controller(nodes, shard_size:)

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -163,7 +163,9 @@ class TestAgainstClusterState < TestingWrapper
     def wait_for_replication
       client_side_timeout = TEST_TIMEOUT_SEC + 1.0
       server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-      @client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+      swap_timeout(@client, timeout: 0.1) do |client|
+        client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+      end
     end
 
     def fetch_cluster_info(key)

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -165,6 +165,8 @@ class TestAgainstClusterState < TestingWrapper
       server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
       swap_timeout(@client, timeout: 0.1) do |client|
         client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+      rescue RedisClient::Cluster::ErrorCollection => e
+        raise unless e.errors.values.all? { |err| err.message.start_with?('ERR WAIT cannot be used with replica instances') }
       end
     end
 


### PR DESCRIPTION
* https://github.com/redis-rb/redis-client/pull/197

The above fixing made our several test cases slow. So we should've shorten the time by any workaround. 

Also, in experimental, I added a test case for Valkey server. The following fixing gave us a stability in a resharding state. But I'll leave our resharding test cases alone for now.

* https://github.com/valkey-io/valkey/pull/495