### PR TITLE
feat: introduce max_startup_sample in ClusterConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ gem 'redis-cluster-client'
 | `:slow_command_timeout` | Integer | `-1` | timeout used for "slow" queries that fetch metdata e.g. CLUSTER NODES, COMMAND |
 | `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
 | `:connect_with_original_config` | Boolean | `false` | `true` if client should retry the connection using the original endpoint that was passed in |
+| `:max_startup_sample` | Integer | `3` | maximum number of nodes to fetch `CLUSTER NODES` information for startup |
 
 Also, [the other generic options](https://github.com/redis-rb/redis-client#configuration) can be passed.
 But `:url`, `:host`, `:port` and `:path` are ignored because they conflict with the `:nodes` option.

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -13,9 +13,6 @@ class RedisClient
     class Node
       include Enumerable
 
-      # It affects to strike a balance between load and stability in initialization or changed states.
-      MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
-
       # less memory consumption, but slow
       USE_CHAR_ARRAY_SLOT = Integer(ENV.fetch('REDIS_CLIENT_USE_CHAR_ARRAY_SLOT', 1)) == 1
 
@@ -197,7 +194,7 @@ class RedisClient
 
       def reload!
         with_reload_lock do
-          with_startup_clients(MAX_STARTUP_SAMPLE) do |startup_clients|
+          with_startup_clients(@config.max_startup_sample) do |startup_clients|
             @node_info = refetch_node_info_list(startup_clients)
             @node_configs = @node_info.to_h do |node_info|
               [node_info.node_key, @config.client_config_for_node(node_info.node_key)]

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -28,7 +28,7 @@ class RedisClient
     attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout,
                 :connect_with_original_config, :startup_nodes, :max_startup_sample
 
-    def initialize(
+    def initialize( # rubocop:disable Metrics/ParameterLists
       nodes: DEFAULT_NODES,
       replica: false,
       replica_affinity: :random,

--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -20,11 +20,13 @@ class RedisClient
     MAX_WORKERS = Integer(ENV.fetch('REDIS_CLIENT_MAX_THREADS', 5))
     # It's used with slow queries of fetching meta data like CLUSTER NODES, COMMAND and so on.
     SLOW_COMMAND_TIMEOUT = Float(ENV.fetch('REDIS_CLIENT_SLOW_COMMAND_TIMEOUT', -1))
+    # It affects to strike a balance between load and stability in initialization or changed states.
+    MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
 
     InvalidClientConfigError = Class.new(::RedisClient::Error)
 
     attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout,
-                :connect_with_original_config, :startup_nodes
+                :connect_with_original_config, :startup_nodes, :max_startup_sample
 
     def initialize(
       nodes: DEFAULT_NODES,
@@ -36,6 +38,7 @@ class RedisClient
       client_implementation: ::RedisClient::Cluster, # for redis gem
       slow_command_timeout: SLOW_COMMAND_TIMEOUT,
       command_builder: ::RedisClient::CommandBuilder,
+      max_startup_sample: MAX_STARTUP_SAMPLE,
       **client_config
     )
 
@@ -51,6 +54,7 @@ class RedisClient
       @connect_with_original_config = connect_with_original_config
       @client_implementation = client_implementation
       @slow_command_timeout = slow_command_timeout
+      @max_startup_sample = max_startup_sample
     end
 
     def inspect


### PR DESCRIPTION
This PR proposes to let users configure individual `RedisClient::Cluster` instances using `max_startup_sample`.

A single application could connect to multiple Redis Clusters of different sizes. Using a single global envvar would mean we either over-sample on small clusters or under-sample on large clusters.

