### PR TITLE
ci: add async-redis to iterations per second for a benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'redis-cluster-client'
 
+gem 'async-redis'
 gem 'benchmark-ips'
 gem 'hiredis-client', '~> 0.6'
 gem 'memory_profiler'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'redis-cluster-client'
 
-gem 'async-redis'
+gem 'async-redis', platform: :mri
 gem 'benchmark-ips'
 gem 'hiredis-client', '~> 0.6'
 gem 'memory_profiler'


### PR DESCRIPTION
https://github.com/socketry/async-redis

```
################################################################################
# single
################################################################################

ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
Warming up --------------------------------------
         single: cli   118.000 i/100ms
       single: envoy    36.000 i/100ms
      single: cproxy    53.000 i/100ms
Calculating -------------------------------------
         single: cli      1.195k (± 5.7%) i/s -      6.018k in   5.053942s
       single: envoy    367.100 (± 3.8%) i/s -      1.872k in   5.107732s
      single: cproxy    531.992 (± 2.3%) i/s -      2.703k in   5.083637s

Comparison:
         single: cli:     1194.9 i/s
      single: cproxy:      532.0 i/s - 2.25x  slower
       single: envoy:      367.1 i/s - 3.26x  slower

ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
Warming up --------------------------------------
       single: async    58.000 i/100ms
Calculating -------------------------------------
       single: async    577.182 (± 5.2%) i/s -      2.900k in   5.040221s
```