### PR TITLE
perf: lessen reload frequency to mitigate load of servers

### DIFF
--- a/test/middlewares/redirect_count.rb
+++ b/test/middlewares/redirect_count.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Middlewares
-  module RedirectionCount
+  module RedirectCount
     class Counter
-      Result = Struct.new('RedirectionCountResult', :moved, :ask, keyword_init: true)
+      Result = Struct.new('RedirectCountResult', :moved, :ask, keyword_init: true)
 
       def initialize
         @moved = 0
@@ -39,9 +39,9 @@ module Middlewares
       super
     rescue ::RedisClient::CommandError => e
       if e.message.start_with?('MOVED')
-        cfg.custom.fetch(:redirection_count).moved
+        cfg.custom.fetch(:redirect_count).moved
       elsif e.message.start_with?('ASK')
-        cfg.custom.fetch(:redirection_count).ask
+        cfg.custom.fetch(:redirect_count).ask
       end
 
       raise
@@ -51,9 +51,9 @@ module Middlewares
       super
     rescue ::RedisClient::CommandError => e
       if e.message.start_with?('MOVED')
-        cfg.custom.fetch(:redirection_count).moved
+        cfg.custom.fetch(:redirect_count).moved
       elsif e.message.start_with?('ASK')
-        cfg.custom.fetch(:redirection_count).ask
+        cfg.custom.fetch(:redirect_count).ask
       end
 
       raise

--- a/test/middlewares/redirect_fake.rb
+++ b/test/middlewares/redirect_fake.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 module Middlewares
-  module RedirectionEmulation
+  module RedirectFake
     Setting = Struct.new(
-      'RedirectionEmulationMiddlewareSetting',
+      'RedirectFakeSetting',
       :slot, :to, :command, keyword_init: true
     )
 
     def call(cmd, cfg)
-      s = cfg.custom.fetch(:redirect)
+      s = cfg.custom.fetch(:redirect_fake)
       raise RedisClient::CommandError, "MOVED #{s.slot} #{s.to}" if cmd == s.command
 
       super
     end
 
     def call_pipelined(cmd, cfg)
-      s = cfg.custom.fetch(:redirect)
+      s = cfg.custom.fetch(:redirect_fake)
       raise RedisClient::CommandError, "MOVED #{s.slot} #{s.to}" if cmd == s.command
 
       super

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -7,19 +7,19 @@ class RedisClient
     module Mixin
       def setup
         @captured_commands = ::Middlewares::CommandCapture::CommandBuffer.new
-        @redirection_count = ::Middlewares::RedirectionCount::Counter.new
+        @redirect_count = ::Middlewares::RedirectCount::Counter.new
         @client = new_test_client
         @client.call('FLUSHDB')
         wait_for_replication
         @captured_commands.clear
-        @redirection_count.clear
+        @redirect_count.clear
       end
 
       def teardown
         @client&.call('FLUSHDB')
         wait_for_replication
         @client&.close
-        flunk(@redirection_count.get) unless @redirection_count.zero?
+        flunk(@redirect_count.get) unless @redirect_count.zero?
       end
 
       def test_config
@@ -850,10 +850,10 @@ class RedisClient
         client2 = new_test_client(
           middlewares: [
             ::RedisClient::Cluster::ErrorIdentification::Middleware,
-            ::Middlewares::RedirectionEmulation
+            ::Middlewares::RedirectFake
           ],
           custom: {
-            redirect: ::Middlewares::RedirectionEmulation::Setting.new(
+            redirect_fake: ::Middlewares::RedirectFake::Setting.new(
               slot: slot, to: broken_primary_key, command: %w[SET testkey client2]
             )
           }
@@ -925,8 +925,8 @@ class RedisClient
       include Mixin
 
       def new_test_client(
-        custom: { captured_commands: @captured_commands, redirection_count: @redirection_count },
-        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectionCount],
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
         **opts
       )
         config = ::RedisClient::ClusterConfig.new(
@@ -946,8 +946,8 @@ class RedisClient
       include Mixin
 
       def new_test_client(
-        custom: { captured_commands: @captured_commands, redirection_count: @redirection_count },
-        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectionCount],
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
         **opts
       )
         config = ::RedisClient::ClusterConfig.new(
@@ -969,8 +969,8 @@ class RedisClient
       include Mixin
 
       def new_test_client(
-        custom: { captured_commands: @captured_commands, redirection_count: @redirection_count },
-        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectionCount],
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
         **opts
       )
         config = ::RedisClient::ClusterConfig.new(
@@ -992,8 +992,8 @@ class RedisClient
       include Mixin
 
       def new_test_client(
-        custom: { captured_commands: @captured_commands, redirection_count: @redirection_count },
-        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectionCount],
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
         **opts
       )
         config = ::RedisClient::ClusterConfig.new(
@@ -1015,8 +1015,8 @@ class RedisClient
       include Mixin
 
       def new_test_client(
-        custom: { captured_commands: @captured_commands, redirection_count: @redirection_count },
-        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectionCount],
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
         **opts
       )
         config = ::RedisClient::ClusterConfig.new(

--- a/test/test_against_cluster_broken.rb
+++ b/test/test_against_cluster_broken.rb
@@ -7,12 +7,13 @@ class TestAgainstClusterBroken < TestingWrapper
 
   def setup
     @captured_commands = ::Middlewares::CommandCapture::CommandBuffer.new
+    @redirect_count = ::Middlewares::RedirectCount::Counter.new
     @client = ::RedisClient.cluster(
       nodes: TEST_NODE_URIS,
       replica: true,
       fixed_hostname: TEST_FIXED_HOSTNAME,
-      custom: { captured_commands: @captured_commands },
-      middlewares: [::Middlewares::CommandCapture],
+      custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+      middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
       **TEST_GENERIC_OPTIONS
     ).new_client
     @client.call('echo', 'init')
@@ -22,11 +23,13 @@ class TestAgainstClusterBroken < TestingWrapper
       **TEST_GENERIC_OPTIONS.merge(timeout: 30.0)
     )
     @captured_commands.clear
+    @redirect_count.clear
   end
 
   def teardown
     @client&.close
     @controller&.close
+    print "#{@redirect_count.get}, ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')} = "
   end
 
   def test_a_replica_is_down

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -7,8 +7,8 @@ require 'redis-cluster-client'
 require 'testing_constants'
 require 'cluster_controller'
 require 'middlewares/command_capture'
-require 'middlewares/redirection_emulation'
-require 'middlewares/redirection_count'
+require 'middlewares/redirect_count'
+require 'middlewares/redirect_fake'
 
 case ENV.fetch('REDIS_CONNECTION_DRIVER', 'ruby')
 when 'hiredis' then require 'hiredis-client'


### PR DESCRIPTION
The following commands are slow query.

* https://redis.io/docs/latest/commands/cluster-nodes/
* https://redis.io/docs/latest/commands/cluster-slots/
* https://redis.io/docs/latest/commands/cluster-shards/

So clients should care about load of servers.

* [Redis OSS cluster client discovery and exponential backoff](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/BestPractices.Clients.Redis.Discovery.html)

This pull request mitigates it.

* #368