### PR TITLE
fix: ensure recoverability from cluster state changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,19 +35,21 @@ jobs:
           - {redis: '8',   ruby: '3.3', compose: compose.valkey.yaml, replica: '2'}
           - {task: test_cluster_broken, redis: '7.2', restart: 'no', startup: '6'}
           - {task: test_cluster_broken, redis: '6.2', restart: 'no', startup: '6'}
-          - {task: test_cluster_scale,  redis: '7.2', compose: compose.scale.yaml, startup: '8'}
-          - {task: test_cluster_scale,  redis: '6.2', compose: compose.scale.yaml, startup: '8'}
           - {redis: '7.2', ruby: '3.2', compose: compose.auth.yaml}
           - {redis: '7.0', ruby: '3.1'}
           - {redis: '6.2', ruby: '3.0'}
           - {redis: '5.0', ruby: '2.7'}
+          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Single', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Pipeline', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Transaction', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale,  redis: '7.2', pattern: 'PubSub', compose: compose.scale.yaml, startup: '8'}
+          - {ruby: 'jruby'}
+          - {ruby: 'truffleruby'}
           - {task: test_cluster_state,  redis: '8', pattern: 'PrimaryOnly', compose: compose.valkey.yaml, replica: '2', startup: '9'}
           - {task: test_cluster_state,  redis: '8', pattern: 'Pooled', compose: compose.valkey.yaml, replica: '2', startup: '9'}
           - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadRandom', compose: compose.valkey.yaml, replica: '2', startup: '9'}
           - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadRandomWithPrimary', compose: compose.valkey.yaml, replica: '2', startup: '9'}
           - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadLatency', compose: compose.valkey.yaml, replica: '2', startup: '9'}
-          - {ruby: 'jruby'}
-          - {ruby: 'truffleruby'}
     env:
       REDIS_VERSION: ${{ matrix.redis || '7.2' }}
       DOCKER_COMPOSE_FILE: ${{ matrix.compose || 'compose.yaml' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,7 @@ jobs:
           - {task: test_cluster_scale, pattern: 'Pipeline', compose: compose.scale.yaml, startup: '8'}
           - {task: test_cluster_scale, pattern: 'Transaction', compose: compose.scale.yaml, startup: '8'}
           - {task: test_cluster_scale, pattern: 'PubSub', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale, pattern: 'Scan', compose: compose.scale.yaml, startup: '8'}
           - {ruby: 'jruby'}
           - {ruby: 'truffleruby'}
           - {task: test_cluster_state, pattern: 'PrimaryOnly', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,23 +33,22 @@ jobs:
           - {redis: '7.2', ruby: '3.3', driver: 'hiredis', compose: compose.ssl.yaml}
           - {redis: '7.2', ruby: '3.3', compose: compose.replica.yaml, replica: '2'}
           - {redis: '8',   ruby: '3.3', compose: compose.valkey.yaml, replica: '2'}
-          - {task: test_cluster_broken, redis: '7.2', restart: 'no', startup: '6'}
-          - {task: test_cluster_broken, redis: '6.2', restart: 'no', startup: '6'}
           - {redis: '7.2', ruby: '3.2', compose: compose.auth.yaml}
+          - {task: test_cluster_broken, restart: 'no', startup: '6'}
           - {redis: '7.0', ruby: '3.1'}
           - {redis: '6.2', ruby: '3.0'}
           - {redis: '5.0', ruby: '2.7'}
-          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Single', compose: compose.scale.yaml, startup: '8'}
-          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Pipeline', compose: compose.scale.yaml, startup: '8'}
-          - {task: test_cluster_scale,  redis: '7.2', pattern: 'Transaction', compose: compose.scale.yaml, startup: '8'}
-          - {task: test_cluster_scale,  redis: '7.2', pattern: 'PubSub', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale, pattern: 'Single', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale, pattern: 'Pipeline', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale, pattern: 'Transaction', compose: compose.scale.yaml, startup: '8'}
+          - {task: test_cluster_scale, pattern: 'PubSub', compose: compose.scale.yaml, startup: '8'}
           - {ruby: 'jruby'}
           - {ruby: 'truffleruby'}
-          - {task: test_cluster_state,  redis: '8', pattern: 'PrimaryOnly', compose: compose.valkey.yaml, replica: '2', startup: '9'}
-          - {task: test_cluster_state,  redis: '8', pattern: 'Pooled', compose: compose.valkey.yaml, replica: '2', startup: '9'}
-          - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadRandom', compose: compose.valkey.yaml, replica: '2', startup: '9'}
-          - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadRandomWithPrimary', compose: compose.valkey.yaml, replica: '2', startup: '9'}
-          - {task: test_cluster_state,  redis: '8', pattern: 'ScaleReadLatency', compose: compose.valkey.yaml, replica: '2', startup: '9'}
+          - {task: test_cluster_state, pattern: 'PrimaryOnly', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
+          - {task: test_cluster_state, pattern: 'Pooled', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
+          - {task: test_cluster_state, pattern: 'ScaleReadRandom', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
+          - {task: test_cluster_state, pattern: 'ScaleReadRandomWithPrimary', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
+          - {task: test_cluster_state, pattern: 'ScaleReadLatency', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
     env:
       REDIS_VERSION: ${{ matrix.redis || '7.2' }}
       DOCKER_COMPOSE_FILE: ${{ matrix.compose || 'compose.yaml' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,6 @@ jobs:
           - {task: test_cluster_scale, pattern: 'Pipeline', compose: compose.scale.yaml, startup: '8'}
           - {task: test_cluster_scale, pattern: 'Transaction', compose: compose.scale.yaml, startup: '8'}
           - {task: test_cluster_scale, pattern: 'PubSub', compose: compose.scale.yaml, startup: '8'}
-          - {task: test_cluster_scale, pattern: 'Scan', compose: compose.scale.yaml, startup: '8'}
           - {ruby: 'jruby'}
           - {ruby: 'truffleruby'}
           - {task: test_cluster_state, pattern: 'PrimaryOnly', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,14 @@ Metrics/AbcSize:
   Exclude:
     - 'test/**/*'
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'test/**/*'
+
 Metrics/ClassLength:
   Max: 500
 

--- a/lib/redis_client/cluster/errors.rb
+++ b/lib/redis_client/cluster/errors.rb
@@ -32,7 +32,7 @@ class RedisClient
       def initialize(errors)
         @errors = {}
         if !errors.is_a?(Hash) || errors.empty?
-          super('')
+          super(errors.to_s)
           return
         end
 

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -193,6 +193,7 @@ class RedisClient
             cluster_state_errors ||= {}
             cluster_state_errors[node_key] = v
           when StandardError
+            cluster_state_errors ||= {} if v.is_a?(::RedisClient::ConnectionError)
             errors ||= {}
             errors[node_key] = v
           else

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -183,6 +183,7 @@ class RedisClient
         end
 
         work_group.close
+        # TODO: implement @router.renew_cluster_state
         raise ::RedisClient::Cluster::ErrorCollection, errors unless errors.nil?
 
         required_redirections&.each do |node_key, v|

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -135,7 +135,7 @@ class RedisClient
 
         command[1] = raw_cursor.to_s
 
-        result_cursor, result_keys = handle_cluster_state_errors { client.call_v(command) }
+        result_cursor, result_keys = client.call_v(command)
         result_cursor = Integer(result_cursor)
 
         client_index += 1 if result_cursor == 0

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -189,7 +189,7 @@ class RedisClient
       end
 
       def find_node(node_key)
-        @node.find_by(node_key)
+        handle_node_reload_error { @node.find_by(node_key) }
       end
 
       def command_exists?(name)

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -35,38 +35,57 @@ class RedisClient
       end
 
       def send_command(method, command, *args, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        handle_cluster_state_errors do
-          cmd = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
-          case cmd
-          when 'ping'     then @node.send_ping(method, command, args).first.then(&TSF.call(block))
-          when 'wait'     then send_wait_command(method, command, args, &block)
-          when 'keys'     then @node.call_replicas(method, command, args).flatten.sort_by(&:to_s).then(&TSF.call(block))
-          when 'dbsize'   then @node.call_replicas(method, command, args).select { |e| e.is_a?(Integer) }.sum.then(&TSF.call(block))
-          when 'scan'     then scan(command, seed: 1)
-          when 'lastsave' then @node.call_all(method, command, args).sort_by(&:to_i).then(&TSF.call(block))
-          when 'role'     then @node.call_all(method, command, args, &block)
-          when 'config'   then send_config_command(method, command, args, &block)
-          when 'client'   then send_client_command(method, command, args, &block)
-          when 'cluster'  then send_cluster_command(method, command, args, &block)
-          when 'memory'   then send_memory_command(method, command, args, &block)
-          when 'script'   then send_script_command(method, command, args, &block)
-          when 'pubsub'   then send_pubsub_command(method, command, args, &block)
-          when 'watch'    then send_watch_command(command, &block)
-          when 'mset', 'mget', 'del'
-            send_multiple_keys_command(cmd, method, command, args, &block)
-          when 'acl', 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
-            @node.call_all(method, command, args).first.then(&TSF.call(block))
-          when 'flushall', 'flushdb'
-            @node.call_primaries(method, command, args).first.then(&TSF.call(block))
-          when 'readonly', 'readwrite', 'shutdown'
-            raise ::RedisClient::Cluster::OrchestrationCommandNotSupported, cmd
-          when 'discard', 'exec', 'multi', 'unwatch'
-            raise ::RedisClient::Cluster::AmbiguousNodeError, cmd
-          else
-            node = assign_node(command)
-            try_send(node, method, command, args, &block)
-          end
+        cmd = ::RedisClient::Cluster::NormalizedCmdName.instance.get_by_command(command)
+        case cmd
+        when 'ping'     then @node.send_ping(method, command, args).first.then(&TSF.call(block))
+        when 'wait'     then send_wait_command(method, command, args, &block)
+        when 'keys'     then @node.call_replicas(method, command, args).flatten.sort_by(&:to_s).then(&TSF.call(block))
+        when 'dbsize'   then @node.call_replicas(method, command, args).select { |e| e.is_a?(Integer) }.sum.then(&TSF.call(block))
+        when 'scan'     then scan(command, seed: 1)
+        when 'lastsave' then @node.call_all(method, command, args).sort_by(&:to_i).then(&TSF.call(block))
+        when 'role'     then @node.call_all(method, command, args, &block)
+        when 'config'   then send_config_command(method, command, args, &block)
+        when 'client'   then send_client_command(method, command, args, &block)
+        when 'cluster'  then send_cluster_command(method, command, args, &block)
+        when 'memory'   then send_memory_command(method, command, args, &block)
+        when 'script'   then send_script_command(method, command, args, &block)
+        when 'pubsub'   then send_pubsub_command(method, command, args, &block)
+        when 'watch'    then send_watch_command(command, &block)
+        when 'mset', 'mget', 'del'
+          send_multiple_keys_command(cmd, method, command, args, &block)
+        when 'acl', 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
+          @node.call_all(method, command, args).first.then(&TSF.call(block))
+        when 'flushall', 'flushdb'
+          @node.call_primaries(method, command, args).first.then(&TSF.call(block))
+        when 'readonly', 'readwrite', 'shutdown'
+          raise ::RedisClient::Cluster::OrchestrationCommandNotSupported, cmd
+        when 'discard', 'exec', 'multi', 'unwatch'
+          raise ::RedisClient::Cluster::AmbiguousNodeError, cmd
+        else
+          node = assign_node(command)
+          try_send(node, method, command, args, &block)
         end
+      rescue ::RedisClient::CircuitBreaker::OpenCircuitError
+        raise
+      rescue ::RedisClient::Cluster::Node::ReloadNeeded
+        renew_cluster_state
+        raise ::RedisClient::Cluster::NodeMightBeDown
+      rescue ::RedisClient::ConnectionError
+        renew_cluster_state
+        raise
+      rescue ::RedisClient::CommandError => e
+        renew_cluster_state if e.message.start_with?('CLUSTERDOWN Hash slot not served')
+        raise
+      rescue ::RedisClient::Cluster::ErrorCollection => e
+        raise if e.errors.any?(::RedisClient::CircuitBreaker::OpenCircuitError)
+
+        renew_cluster_state if e.errors.values.any? do |err|
+          next false if ::RedisClient::Cluster::ErrorIdentification.identifiable?(err) && @node.none? { |c| ::RedisClient::Cluster::ErrorIdentification.client_owns_error?(err, c) }
+
+          err.message.start_with?('CLUSTERDOWN Hash slot not served') || err.is_a?(::RedisClient::ConnectionError)
+        end
+
+        raise
       end
 
       # @see https://redis.io/docs/reference/cluster-spec/#redirection-and-resharding Redirection and resharding
@@ -141,6 +160,9 @@ class RedisClient
         client_index += 1 if result_cursor == 0
 
         [((result_cursor << 8) + client_index).to_s, result_keys]
+      rescue ::RedisClient::ConnectionError
+        renew_cluster_state
+        raise
       end
 
       def assign_node(command)
@@ -356,31 +378,6 @@ class RedisClient
                  else replies
                  end
         block_given? ? yield(result) : result
-      end
-
-      def handle_cluster_state_errors # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        yield
-      rescue ::RedisClient::CircuitBreaker::OpenCircuitError
-        raise
-      rescue ::RedisClient::Cluster::Node::ReloadNeeded
-        renew_cluster_state
-        raise ::RedisClient::Cluster::NodeMightBeDown
-      rescue ::RedisClient::ConnectionError
-        renew_cluster_state
-        raise
-      rescue ::RedisClient::CommandError => e
-        renew_cluster_state if e.message.start_with?('CLUSTERDOWN Hash slot not served')
-        raise
-      rescue ::RedisClient::Cluster::ErrorCollection => e
-        raise if e.errors.any?(::RedisClient::CircuitBreaker::OpenCircuitError)
-
-        renew_cluster_state if e.errors.values.any? do |err|
-          next false if ::RedisClient::Cluster::ErrorIdentification.identifiable?(err) && @node.none? { |c| ::RedisClient::Cluster::ErrorIdentification.client_owns_error?(err, c) }
-
-          err.message.start_with?('CLUSTERDOWN Hash slot not served') || err.is_a?(::RedisClient::ConnectionError)
-        end
-
-        raise
       end
 
       def handle_node_reload_error(retry_count: 1)

--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -105,7 +105,7 @@ class ClusterController
     wait_cluster_recovering(@clients, max_attempts: @max_attempts)
   end
 
-  def start_resharding(slot:, src_node_key:, dest_node_key:) # rubocop:disable Metrics/CyclomaticComplexity
+  def start_resharding(slot:, src_node_key:, dest_node_key:)
     rows = associate_with_clients_and_nodes(@clients)
     src_info = rows.find { |r| r.node_key == src_node_key || r.client_node_key == src_node_key }
     dest_info = rows.find { |r| r.node_key == dest_node_key || r.client_node_key == dest_node_key }
@@ -140,7 +140,7 @@ class ClusterController
     wait_replication_delay(@clients, replica_size: @replica_size, timeout: @timeout)
   end
 
-  def finish_resharding(slot:, src_node_key:, dest_node_key:) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def finish_resharding(slot:, src_node_key:, dest_node_key:)
     rows = associate_with_clients_and_nodes(@clients)
     src_info = rows.find { |r| r.node_key == src_node_key || r.client_node_key == src_node_key }
     dest_info = rows.find { |r| r.node_key == dest_node_key || r.client_node_key == dest_node_key }
@@ -161,7 +161,7 @@ class ClusterController
     wait_replication_delay(@clients, replica_size: @replica_size, timeout: @timeout)
   end
 
-  def scale_out(primary_url:, replica_url:) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def scale_out(primary_url:, replica_url:)
     # @see https://redis.io/docs/manual/scaling/
     rows = associate_with_clients_and_nodes(@clients)
     target_host, target_port = rows.find(&:primary?)&.node_key&.split(':')
@@ -193,7 +193,7 @@ class ClusterController
     end
   end
 
-  def scale_in # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def scale_in
     rows = associate_with_clients_and_nodes(@clients)
 
     primary_info = rows.reject(&:empty_slots?).min_by(&:slot_size)
@@ -465,7 +465,7 @@ class ClusterController
     end
   end
 
-  def parse_cluster_nodes(rows) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def parse_cluster_nodes(rows)
     rows.map do |row|
       flags = row[2].split(',')
       slots = if row[8].nil?

--- a/test/redis_client/cluster/test_errors.rb
+++ b/test/redis_client/cluster/test_errors.rb
@@ -50,7 +50,8 @@ class RedisClient
             errors: { '127.0.0.1:6379' => DummyError.new('foo'), '127.0.0.1:6380' => DummyError.new('bar') },
             want: { msg: 'Errors occurred on any node: 127.0.0.1:6379: foo, 127.0.0.1:6380: bar', size: 2 }
           },
-          { errors: {}, want: { msg: '', size: 0 } },
+          { errors: {}, want: { msg: '{}', size: 0 } },
+          { errors: [], want: { msg: '[]', size: 0 } },
           { errors: '', want: { msg: '', size: 0 } },
           { errors: nil, want: { msg: '', size: 0 } }
         ].each_with_index do |c, idx|

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -352,7 +352,7 @@ class RedisClient
         assert_equal(want, got, 'Case: scale read')
       end
 
-      def test_clients_for_scanning # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def test_clients_for_scanning
         test_config = @test_node.instance_variable_get(:@config)
         want = @test_node_info_list.select(&:primary?)
                                    .map(&:node_key)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -737,7 +737,7 @@ class RedisClient
         end
       end
 
-      def test_dedicated_commands # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def test_dedicated_commands
         10.times { |i| @client.call('SET', "key#{i}", i) }
         wait_for_replication
         [

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -248,7 +248,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        all_keys = NUMBER_OF_KEYS.map { |i| "key#{i}" }
+        all_keys = Array.new(NUMBER_OF_KEYS) { |i| "key#{i}" }
         count = 0
 
         @client.scan do |key|
@@ -260,7 +260,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_in
-        all_keys = NUMBER_OF_KEYS.map { |i| "key#{i}" }
+        all_keys = Array.new(NUMBER_OF_KEYS) { |i| "key#{i}" }
 
         retryable(attempts: 3) do
           count = 0

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -227,7 +227,8 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          assert_equal(['ssubscribe', 'what?', 1], pubsub.next_event(0.01))
+          channels.each { |c| assert_equal(['ssubscribe', c, 1], pubsub.next_event(0.01)) }
+          assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close
         end
@@ -238,7 +239,8 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          assert_equal(['ssubscribe', 'what?', 1], pubsub.next_event(0.01))
+          channels.each { |c| assert_equal(['ssubscribe', c, 1], pubsub.next_event(0.01)) }
+          assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close
         end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -261,17 +261,14 @@ module TestAgainstClusterScale
 
       def do_test_after_scaled_in
         all_keys = Array.new(NUMBER_OF_KEYS) { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.flatten.sort
+        count = 0
 
-        retryable(attempts: 3) do
-          count = 0
-
-          @client.scan do |key|
-            count += 1
-            assert_includes(all_keys, key, 'Case: key')
-          end
-
-          assert_equal(all_keys.size, count, 'Case: count')
+        @client.scan do |key|
+          count += 1
+          assert_includes(all_keys, key, 'Case: key')
         end
+
+        assert_equal(all_keys.size, count, 'Case: count')
       end
     end
   end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -187,9 +187,9 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each_value do |numbers|
-          keys = numbers.map { |i| "{group#{i / HASH_TAG_GRAIN}}:key#{i}" }
-          got = @client.multi(watch: (i / HASH_TAG_GRAIN).odd? ? nil : keys) do |tx|
+        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each do |group, numbers|
+          keys = numbers.map { |i| "{group#{group}}:key#{i}" }
+          got = @client.multi(watch: group.odd? ? nil : keys) do |tx|
             keys.each { |key| tx.call('INCR', key) }
           end
 
@@ -199,10 +199,10 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_in
-        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each_value do |numbers|
-          keys = numbers.map { |i| "{group#{i / HASH_TAG_GRAIN}}:key#{i}" }
+        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each do |group, numbers|
+          keys = numbers.map { |i| "{group#{group}}:key#{i}" }
           got = retryable(attempts: MAX_ATTEMPTS) do
-            @client.multi(watch: (i / HASH_TAG_GRAIN).odd? ? nil : keys) do |tx|
+            @client.multi(watch: group.odd? ? nil : keys) do |tx|
               keys.each { |key| tx.call('INCR', key) }
             end
           end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -223,7 +223,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        NUMBER_OF_KEYS.times do |i|
+        1000.times do |i|
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', "chan#{i}")
           event = pubsub.next_event(0.01)
@@ -235,9 +235,7 @@ module TestAgainstClusterScale
         end
       end
 
-      def do_test_after_scaled_in
-        do_test_after_scaled_out # auto retry
-      end
+      alias do_test_after_scaled_in do_test_after_scaled_out
     end
   end
 end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -248,7 +248,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        all_keys = NUMBER_OF_KEYS.flat_map { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.sort
+        all_keys = Array.new(NUMBER_OF_KEYS) { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.flatten.sort
         count = 0
 
         @client.scan do |key|
@@ -260,7 +260,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_in
-        all_keys = NUMBER_OF_KEYS.flat_map { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.sort
+        all_keys = Array.new(NUMBER_OF_KEYS) { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.flatten.sort
 
         retryable(attempts: 3) do
           count = 0

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -248,7 +248,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        all_keys = Array.new(NUMBER_OF_KEYS) { |i| "key#{i}" }
+        all_keys = NUMBER_OF_KEYS.flat_map { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.sort
         count = 0
 
         @client.scan do |key|
@@ -260,7 +260,7 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_in
-        all_keys = Array.new(NUMBER_OF_KEYS) { |i| "key#{i}" }
+        all_keys = NUMBER_OF_KEYS.flat_map { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.sort
 
         retryable(attempts: 3) do
           count = 0

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -223,11 +223,25 @@ module TestAgainstClusterScale
       end
 
       def do_test_after_scaled_out
-        # TODO: impl
+        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each do |group, numbers|
+          channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
+          pubsub = @client.pubsub
+          pubsub.call('SSUBSCRIBE', *channels)
+          assert_equal(['ssubscribe', 'what?', 1], pubsub.next_event(0.01))
+        ensure
+          pubsub&.close
+        end
       end
 
       def do_test_after_scaled_in
-        # TODO: impl
+        NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each do |group, numbers|
+          channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
+          pubsub = @client.pubsub
+          pubsub.call('SSUBSCRIBE', *channels)
+          assert_equal(['ssubscribe', 'what?', 1], pubsub.next_event(0.01))
+        ensure
+          pubsub&.close
+        end
       end
     end
   end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -238,4 +238,41 @@ module TestAgainstClusterScale
       alias do_test_after_scaled_in do_test_after_scaled_out
     end
   end
+
+  if PATTERN == 'Scan' || PATTERN.empty?
+    class Scan < TestingWrapper
+      include Mixin
+
+      def self.test_order
+        :alpha
+      end
+
+      def do_test_after_scaled_out
+        all_keys = NUMBER_OF_KEYS.map { |i| "key#{i}" }
+        count = 0
+
+        @client.scan do |key|
+          count += 1
+          assert_includes(all_keys, key, 'Case: key')
+        end
+
+        assert_equal(all_keys.size, count, 'Case: count')
+      end
+
+      def do_test_after_scaled_in
+        all_keys = NUMBER_OF_KEYS.map { |i| "key#{i}" }
+
+        retryable(attempts: 3) do
+          count = 0
+
+          @client.scan do |key|
+            count += 1
+            assert_includes(all_keys, key, 'Case: key')
+          end
+
+          assert_equal(all_keys.size, count, 'Case: count')
+        end
+      end
+    end
+  end
 end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -193,7 +193,7 @@ module TestAgainstClusterScale
             keys.each { |key| tx.call('INCR', key) }
           end
 
-          want = numbers.map { |i| (i + 1).to_s }
+          want = numbers.map { |i| (i + 1) }
           assert_equal(want, got, 'Case: INCR')
         end
       end
@@ -205,7 +205,7 @@ module TestAgainstClusterScale
             keys.each { |key| tx.call('INCR', key) }
           end
 
-          want = numbers.map { |i| (i + 1).to_s }
+          want = numbers.map { |i| (i + 2) }
           assert_equal(want, got, 'Case: INCR')
         end
       end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -227,7 +227,7 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          channels.each { |c| assert_equal(['ssubscribe', c, 1], pubsub.next_event(0.01)) }
+          channels.each_with_index { |c, i| assert_equal(['ssubscribe', c, i + 1], pubsub.next_event(0.01)) }
           assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close
@@ -239,7 +239,7 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          channels.each { |c| assert_equal(['ssubscribe', c, 1], pubsub.next_event(0.01)) }
+          channels.each_with_index { |c, i| assert_equal(['ssubscribe', c, i + 1], pubsub.next_event(0.01)) }
           assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -2,115 +2,211 @@
 
 require 'testing_helper'
 
-class TestAgainstClusterScale < TestingWrapper
-  WAIT_SEC = 1
-  MAX_ATTEMPTS = 20
-  NUMBER_OF_KEYS = 20_000
+module TestAgainstClusterScale
+  PATTERN = ENV.fetch('TEST_CLASS_PATTERN', '')
 
-  def self.test_order
-    :alpha
-  end
+  module Mixin
+    WAIT_SEC = 1
+    MAX_ATTEMPTS = 20
+    NUMBER_OF_KEYS = 20_000
+    MAX_PIPELINE_SIZE = 40
+    SLICED_NUMBERS = (0...NUMBER_OF_KEYS).each_slice(MAX_PIPELINE_SIZE).freeze
 
-  def setup
-    @captured_commands = ::Middlewares::CommandCapture::CommandBuffer.new
-    @redirect_count = ::Middlewares::RedirectCount::Counter.new
-    @client = ::RedisClient.cluster(
-      nodes: TEST_NODE_URIS,
-      replica: true,
-      fixed_hostname: TEST_FIXED_HOSTNAME,
-      custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
-      middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
-      **TEST_GENERIC_OPTIONS
-    ).new_client
-    @client.call('echo', 'init')
-    @captured_commands.clear
-    @redirect_count.clear
-    @cluster_down_error_count = 0
-  end
-
-  def teardown
-    @client&.close
-    @controller&.close
-    print "#{@redirect_count.get}, "\
-      "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')}, "\
-      "ClusterDownError: #{@cluster_down_error_count} = "
-  end
-
-  def test_01_scale_out
-    @controller = build_cluster_controller(TEST_NODE_URIS, shard_size: 3)
-
-    @client.pipelined { |pi| NUMBER_OF_KEYS.times { |i| pi.call('SET', "key#{i}", i) } }
-    wait_for_replication
-
-    primary_url, replica_url = build_additional_node_urls
-    @controller.scale_out(primary_url: primary_url, replica_url: replica_url)
-
-    NUMBER_OF_KEYS.times { |i| assert_equal(i.to_s, @client.call('GET', "key#{i}"), "Case: key#{i}") }
-
-    want = (TEST_NODE_URIS + build_additional_node_urls).size
-    got = @client.instance_variable_get(:@router)
-                 .instance_variable_get(:@node)
-                 .instance_variable_get(:@topology)
-                 .instance_variable_get(:@clients)
-                 .size
-    assert_equal(want, got, 'Case: number of nodes')
-    refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
-  end
-
-  def test_02_scale_in
-    @controller = build_cluster_controller(TEST_NODE_URIS + build_additional_node_urls, shard_size: 4)
-    @controller.scale_in
-
-    NUMBER_OF_KEYS.times do |i|
-      got = retry_call(attempts: MAX_ATTEMPTS) { @client.call('GET', "key#{i}") }
-      assert_equal(i.to_s, got, "Case: key#{i}")
+    def setup
+      @captured_commands = ::Middlewares::CommandCapture::CommandBuffer.new
+      @redirect_count = ::Middlewares::RedirectCount::Counter.new
+      @client = ::RedisClient.cluster(
+        nodes: TEST_NODE_URIS,
+        replica: true,
+        fixed_hostname: TEST_FIXED_HOSTNAME,
+        custom: { captured_commands: @captured_commands, redirect_count: @redirect_count },
+        middlewares: [::Middlewares::CommandCapture, ::Middlewares::RedirectCount],
+        **TEST_GENERIC_OPTIONS
+      ).new_client
+      @client.call('echo', 'init')
+      @captured_commands.clear
+      @redirect_count.clear
+      @cluster_down_error_count = 0
     end
 
-    want = TEST_NODE_URIS.size
-    got = @client.instance_variable_get(:@router)
-                 .instance_variable_get(:@node)
-                 .instance_variable_get(:@topology)
-                 .instance_variable_get(:@clients)
-                 .size
-    assert_equal(want, got, 'Case: number of nodes')
-    refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
-  end
+    def teardown
+      @client&.close
+      @controller&.close
+      print "#{@redirect_count.get}, "\
+        "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')}, "\
+        "ClusterDownError: #{@cluster_down_error_count} = "
+    end
 
-  private
+    def test_01_scale_out
+      SLICED_NUMBERS.each do |numbers|
+        @client.pipelined do |pi|
+          numbers.each { |i| pi.call('SET', "key#{i}", i) }
+        end
+      end
 
-  def wait_for_replication
-    client_side_timeout = TEST_TIMEOUT_SEC + 1.0
-    server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
-    swap_timeout(@client, timeout: 0.1) do |client|
-      client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+      wait_for_replication
+
+      primary_url, replica_url = build_additional_node_urls
+      @controller = build_cluster_controller(TEST_NODE_URIS, shard_size: 3)
+      @controller.scale_out(primary_url: primary_url, replica_url: replica_url)
+
+      do_test_after_scaled_out
+
+      want = (TEST_NODE_URIS + build_additional_node_urls).size
+      got = @client.instance_variable_get(:@router)
+                   .instance_variable_get(:@node)
+                   .instance_variable_get(:@topology)
+                   .instance_variable_get(:@clients)
+                   .size
+      assert_equal(want, got, 'Case: number of nodes')
+
+      refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
+    end
+
+    def test_02_scale_in
+      @controller = build_cluster_controller(TEST_NODE_URIS + build_additional_node_urls, shard_size: 4)
+      @controller.scale_in
+
+      do_test_after_scaled_in
+
+      want = TEST_NODE_URIS.size
+      got = @client.instance_variable_get(:@router)
+                   .instance_variable_get(:@node)
+                   .instance_variable_get(:@topology)
+                   .instance_variable_get(:@clients)
+                   .size
+      assert_equal(want, got, 'Case: number of nodes')
+
+      refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
+    end
+
+    private
+
+    def wait_for_replication
+      client_side_timeout = TEST_TIMEOUT_SEC + 1.0
+      server_side_timeout = (TEST_TIMEOUT_SEC * 1000).to_i
+      swap_timeout(@client, timeout: 0.1) do |client|
+        client.blocking_call(client_side_timeout, 'WAIT', TEST_REPLICA_SIZE, server_side_timeout)
+      end
+    end
+
+    def build_cluster_controller(nodes, shard_size:)
+      ClusterController.new(
+        nodes,
+        shard_size: shard_size,
+        replica_size: TEST_REPLICA_SIZE,
+        **TEST_GENERIC_OPTIONS.merge(timeout: 30.0)
+      )
+    end
+
+    def build_additional_node_urls
+      max = TEST_REDIS_PORTS.max
+      (max + 1..max + 2).map { |port| "#{TEST_REDIS_SCHEME}://#{TEST_REDIS_HOST}:#{port}" }
+    end
+
+    def retryable(attempts:)
+      loop do
+        raise MaxRetryExceeded if attempts <= 0
+
+        attempts -= 1
+        break yield
+      rescue ::RedisClient::CommandError => e
+        raise unless e.message.start_with?('CLUSTERDOWN Hash slot not served')
+
+        @cluster_down_error_count += 1
+        sleep WAIT_SEC
+      end
     end
   end
 
-  def build_cluster_controller(nodes, shard_size:)
-    ClusterController.new(
-      nodes,
-      shard_size: shard_size,
-      replica_size: TEST_REPLICA_SIZE,
-      **TEST_GENERIC_OPTIONS.merge(timeout: 30.0)
-    )
+  if PATTERN == 'Single' || PATTERN.empty?
+    class Single < TestingWrapper
+      include Mixin
+
+      def self.test_order
+        :alpha
+      end
+
+      def do_test_after_scaled_out
+        NUMBER_OF_KEYS.times do |i|
+          assert_equal(i.to_s, @client.call('GET', "key#{i}"), "Case: key#{i}")
+        end
+      end
+
+      def do_test_after_scaled_in
+        NUMBER_OF_KEYS.times do |i|
+          got = retryable(attempts: MAX_ATTEMPTS) { @client.call('GET', "key#{i}") }
+          assert_equal(i.to_s, got, "Case: key#{i}")
+        end
+      end
+    end
   end
 
-  def build_additional_node_urls
-    max = TEST_REDIS_PORTS.max
-    (max + 1..max + 2).map { |port| "#{TEST_REDIS_SCHEME}://#{TEST_REDIS_HOST}:#{port}" }
+  if PATTERN == 'Pipeline' || PATTERN.empty?
+    class Pipeline < TestingWrapper
+      include Mixin
+
+      def self.test_order
+        :alpha
+      end
+
+      def do_test_after_scaled_out
+        SLICED_NUMBERS.each do |numbers|
+          got = @client.pipelined do |pi|
+            numbers.each { |i| pi.call('GET', "key#{i}") }
+          end
+
+          assert_equal(numbers.map(&:to_s), got, 'Case: GET')
+        end
+      end
+
+      def do_test_after_scaled_in
+        SLICED_NUMBERS.each do |numbers|
+          got = retryable(attempts: MAX_ATTEMPTS) do
+            @client.pipelined do |pi|
+              numbers.each { |i| pi.call('GET', "key#{i}") }
+            end
+          end
+
+          assert_equal(numbers.map(&:to_s), got, 'Case: GET')
+        end
+      end
+    end
   end
 
-  def retry_call(attempts:)
-    loop do
-      raise MaxRetryExceeded if attempts <= 0
+  if PATTERN == 'Transaction' || PATTERN.empty?
+    class Transaction < TestingWrapper
+      include Mixin
 
-      attempts -= 1
-      break yield
-    rescue ::RedisClient::CommandError => e
-      raise unless e.message.start_with?('CLUSTERDOWN Hash slot not served')
+      def self.test_order
+        :alpha
+      end
 
-      @cluster_down_error_count += 1
-      sleep WAIT_SEC
+      def do_test_after_scaled_out
+        # TODO: impl
+      end
+
+      def do_test_after_scaled_in
+        # TODO: impl
+      end
+    end
+  end
+
+  if PATTERN == 'PubSub' || PATTERN.empty?
+    class PubSub < TestingWrapper
+      include Mixin
+
+      def self.test_order
+        :alpha
+      end
+
+      def do_test_after_scaled_out
+        # TODO: impl
+      end
+
+      def do_test_after_scaled_in
+        # TODO: impl
+      end
     end
   end
 end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -238,38 +238,4 @@ module TestAgainstClusterScale
       alias do_test_after_scaled_in do_test_after_scaled_out
     end
   end
-
-  if PATTERN == 'Scan' || PATTERN.empty?
-    class Scan < TestingWrapper
-      include Mixin
-
-      def self.test_order
-        :alpha
-      end
-
-      def do_test_after_scaled_out
-        all_keys = Array.new(NUMBER_OF_KEYS) { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.flatten.sort
-        count = 0
-
-        @client.scan do |key|
-          count += 1
-          assert_includes(all_keys, key, 'Case: key')
-        end
-
-        assert_equal(all_keys.size, count, 'Case: count')
-      end
-
-      def do_test_after_scaled_in
-        all_keys = Array.new(NUMBER_OF_KEYS) { |i| ["key#{i}", "{group#{i / HASH_TAG_GRAIN}}:key#{i}"] }.flatten.sort
-        count = 0
-
-        @client.scan do |key|
-          count += 1
-          assert_includes(all_keys, key, 'Case: key')
-        end
-
-        assert_equal(all_keys.size, count, 'Case: count')
-      end
-    end
-  end
 end

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -189,7 +189,7 @@ module TestAgainstClusterScale
       def do_test_after_scaled_out
         NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each_value do |numbers|
           keys = numbers.map { |i| "{group#{i / HASH_TAG_GRAIN}}:key#{i}" }
-          got = @client.multi(watch: keys) do |tx|
+          got = @client.multi(watch: (i / HASH_TAG_GRAIN).odd? ? nil : keys) do |tx|
             keys.each { |key| tx.call('INCR', key) }
           end
 
@@ -201,8 +201,10 @@ module TestAgainstClusterScale
       def do_test_after_scaled_in
         NUMBER_OF_KEYS.times.group_by { |i| i / HASH_TAG_GRAIN }.each_value do |numbers|
           keys = numbers.map { |i| "{group#{i / HASH_TAG_GRAIN}}:key#{i}" }
-          got = @client.multi(watch: keys) do |tx|
-            keys.each { |key| tx.call('INCR', key) }
+          got = retryable(attempts: MAX_ATTEMPTS) do
+            @client.multi(watch: (i / HASH_TAG_GRAIN).odd? ? nil : keys) do |tx|
+              keys.each { |key| tx.call('INCR', key) }
+            end
           end
 
           want = numbers.map { |i| (i + 2) }

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -227,7 +227,21 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          channels.each_with_index { |c, i| assert_equal(['ssubscribe', c, i + 1], pubsub.next_event(0.01)) }
+
+          channels.each_with_index do |c, i|
+            event = pubsub.next_event(0.01)
+            break if event.nil?
+
+            assert_equal(['ssubscribe', c, i + 1], event)
+          end
+
+          channels.each_with_index do |c, i| # rubocop:disable Style/CombinableLoops
+            event = pubsub.next_event(0.01)
+            break if event.nil?
+
+            assert_equal(['ssubscribe', c, i + 1], event)
+          end
+
           assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close
@@ -239,7 +253,21 @@ module TestAgainstClusterScale
           channels = numbers.map { |i| "{group#{group}}:channel#{i}" }
           pubsub = @client.pubsub
           pubsub.call('SSUBSCRIBE', *channels)
-          channels.each_with_index { |c, i| assert_equal(['ssubscribe', c, i + 1], pubsub.next_event(0.01)) }
+
+          channels.each_with_index do |c, i|
+            event = pubsub.next_event(0.01)
+            break if event.nil?
+
+            assert_equal(['ssubscribe', c, i + 1], event)
+          end
+
+          channels.each_with_index do |c, i| # rubocop:disable Style/CombinableLoops
+            event = pubsub.next_event(0.01)
+            break if event.nil?
+
+            assert_equal(['ssubscribe', c, i + 1], event)
+          end
+
           assert_nil(pubsub.next_event(0.01))
         ensure
           pubsub&.close

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -3,10 +3,11 @@
 require 'testing_helper'
 
 module TestAgainstClusterState
-  SLOT_SIZE = 16_384
   PATTERN = ENV.fetch('TEST_CLASS_PATTERN', '')
 
   module Mixin
+    SLOT_SIZE = 16_384
+
     def setup
       @controller = ClusterController.new(
         TEST_NODE_URIS,


### PR DESCRIPTION
Several kinds of errors may be a sign of the time to renew the cluster state information in our client. So that we should handle these errors and update the state to prevent continuously throwing them. Also, we can retry a process as possible internally.

A portion of this fix is related to the following:

* #368