### PR TITLE
test: add a case for node recovery in a broken cluster

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         include:
           - {redis: '7.2', ruby: '3.3'}
+          - {task: test_cluster_broken, restart: 'no', startup: '6'}
           - {redis: '7.2', ruby: '3.3', compose: compose.ssl.yaml}
           - {redis: '7.2', ruby: '3.3', driver: 'hiredis'}
           - {redis: '7.2', ruby: '3.3', driver: 'hiredis', compose: compose.ssl.yaml}
@@ -39,7 +40,6 @@ jobs:
           - {task: test_cluster_state, pattern: 'ScaleReadLatency', compose: compose.valkey.yaml, redis: '8', replica: '2', startup: '9'}
           - {ruby: 'jruby'}
           - {ruby: 'truffleruby'}
-          - {task: test_cluster_broken, restart: 'no', startup: '6'}
           - {task: test_cluster_down}
           - {redis: '8',   ruby: '3.3', compose: compose.valkey.yaml, replica: '2'}
           - {redis: '7.2', ruby: '3.2', compose: compose.auth.yaml}

--- a/compose.valkey.yaml
+++ b/compose.valkey.yaml
@@ -86,22 +86,3 @@ services:
         condition: service_healthy
       node9:
         condition: service_healthy
-  ruby:
-    image: "ruby:${RUBY_VERSION:-3}"
-    restart: always
-    working_dir: /client
-    volumes:
-      - .:/client
-    command:
-      - ruby
-      - "-e"
-      - 'Signal.trap(:INT, "EXIT"); Signal.trap(:TERM, "EXIT"); loop { sleep 1 }'
-    environment:
-      REDIS_HOST: node1
-    cap_drop:
-      - ALL
-    healthcheck:
-      test: ["CMD", "ruby", "-e", "'puts 1'"]
-      interval: "5s"
-      timeout: "3s"
-      retries: 3


### PR DESCRIPTION
Although this way may not work for macOS, I'd like to expand on our test cases by an easy way with Docker.

* #354

That said, this test case is too slow.