### PR TITLE
fix: the behavior of subscription in pubsub when nodes are unstable

### DIFF
--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -35,19 +35,15 @@ class RedisClient
           # Ruby VM allocates 1 MB memory as a stack for a thread.
           # It is a fixed size but we can modify the size with some environment variables.
           # So it consumes memory 1 MB multiplied a number of workers.
-          Thread.new(client, queue) do |pubsub, q|
-            prev_err = nil
-
+          Thread.new(client, queue, nil) do |pubsub, q, prev_err|
             loop do
               q << pubsub.next_event
               prev_err = nil
             rescue StandardError => e
-              if e.instance_of?(prev_err.class) && e.message == prev_err&.message
-                sleep 0.005
-              else
-                q << e
-                prev_err = e
-              end
+              next sleep 0.005 if e.instance_of?(prev_err.class) && e.message == prev_err&.message
+
+              q << e
+              prev_err = e
             end
           end
         end


### PR DESCRIPTION
* Don't clear subscribed messages while recovering subscriptions to prevent lost backlogs.
* Sleep some duration for mitigating CPU consumption while repeating the same error such as ConnectionError.