### PR TITLE
fix: make no-concurrency mode default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gem 'redis-cluster-client'
 | `:replica_affinity` | Symbol or String | `:random` | scale reading strategy, `:random`, `random_with_primary` or `:latency` are valid |
 | `:fixed_hostname` | String | `nil` | required if client should connect to single endpoint with SSL |
 | `:slow_command_timeout` | Integer | `-1` | timeout used for "slow" queries that fetch metdata e.g. CLUSTER NODES, COMMAND |
-| `:concurrency` | Hash | `{ model: :on_demand, size: 5}` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
+| `:concurrency` | Hash | `{ model: :none }` | concurrency settings, `:on_demand`, `:pooled` and `:none` are valid models, size is a max number of workers, `:none` model is no concurrency, Please choose the one suited your environment if needed. |
 | `:connect_with_original_config` | Boolean | `false` | `true` if client should retry the connection using the original endpoint that was passed in |
 | `:max_startup_sample` | Integer | `3` | maximum number of nodes to fetch `CLUSTER NODES` information for startup |
 

--- a/lib/redis_client/cluster/concurrent_worker.rb
+++ b/lib/redis_client/cluster/concurrent_worker.rb
@@ -71,14 +71,12 @@ class RedisClient
 
       module_function
 
-      def create(model: :on_demand, size: 5)
-        size = size.positive? ? size : 5
-
+      def create(model: :none, size: 5)
         case model
-        when :on_demand, nil then ::RedisClient::Cluster::ConcurrentWorker::OnDemand.new(size: size)
-        when :pooled then ::RedisClient::Cluster::ConcurrentWorker::Pooled.new(size: size)
         when :none then ::RedisClient::Cluster::ConcurrentWorker::None.new
-        else raise ArgumentError, "Unknown model: #{model}"
+        when :on_demand then ::RedisClient::Cluster::ConcurrentWorker::OnDemand.new(size: size)
+        when :pooled then ::RedisClient::Cluster::ConcurrentWorker::Pooled.new(size: size)
+        else raise ArgumentError, "unknown model: #{model}"
         end
       end
     end

--- a/lib/redis_client/cluster/concurrent_worker/on_demand.rb
+++ b/lib/redis_client/cluster/concurrent_worker/on_demand.rb
@@ -5,6 +5,8 @@ class RedisClient
     module ConcurrentWorker
       class OnDemand
         def initialize(size:)
+          raise ArgumentError, "size must be positive: #{size}" unless size.positive?
+
           @q = SizedQueue.new(size)
         end
 

--- a/lib/redis_client/cluster/concurrent_worker/pooled.rb
+++ b/lib/redis_client/cluster/concurrent_worker/pooled.rb
@@ -11,6 +11,8 @@ class RedisClient
       # So it consumes memory 1 MB multiplied a number of workers.
       class Pooled
         def initialize(size:)
+          raise ArgumentError, "size must be positive: #{size}" unless size.positive?
+
           @size = size
           setup
         end

--- a/test/redis_client/test_cluster_config.rb
+++ b/test/redis_client/test_cluster_config.rb
@@ -103,6 +103,18 @@ class RedisClient
       assert_equal(::RedisClient::CommandBuilder, ::RedisClient::ClusterConfig.new.command_builder)
     end
 
+    def test_concurrency
+      [
+        { value: nil, want: { model: :none } },
+        { value: { model: :none }, want: { model: :none } },
+        { value: { model: :on_demand, size: 3 }, want: { model: :on_demand, size: 3 } },
+        { value: { model: :pooled, size: 6 }, want: { model: :pooled, size: 6 } }
+      ].each do |c|
+        cfg = ::RedisClient::ClusterConfig.new(concurrency: c[:value])
+        assert_equal(c[:want], cfg.instance_variable_get(:@concurrency))
+      end
+    end
+
     def test_build_node_configs
       config = ::RedisClient::ClusterConfig.new
       [


### PR DESCRIPTION
```
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [x86_64-linux]
Warming up --------------------------------------
 pipelined: ondemand    72.000 i/100ms
   pipelined: pooled    82.000 i/100ms
     pipelined: none    84.000 i/100ms
    pipelined: envoy    80.000 i/100ms
   pipelined: cproxy    39.000 i/100ms
Calculating -------------------------------------
 pipelined: ondemand    715.452 (± 6.6%) i/s    (1.40 ms/i) -      3.600k in   5.064794s
   pipelined: pooled    830.765 (± 0.7%) i/s    (1.20 ms/i) -      4.182k in   5.034200s
     pipelined: none    846.257 (± 5.8%) i/s    (1.18 ms/i) -      4.284k in   5.084215s
    pipelined: envoy    805.275 (± 7.0%) i/s    (1.24 ms/i) -      4.000k in   5.007049s
   pipelined: cproxy    400.326 (± 5.2%) i/s    (2.50 ms/i) -      2.028k in   5.085483s

Comparison:
     pipelined: none:      846.3 i/s
   pipelined: pooled:      830.8 i/s - same-ish: difference falls within error
    pipelined: envoy:      805.3 i/s - same-ish: difference falls within error
 pipelined: ondemand:      715.5 i/s - 1.18x  slower
   pipelined: cproxy:      400.3 i/s - 2.11x  slower
```

The thread-initialization cost is too expensive against a standart-scale service.