### PR TITLE
Add `RedisClient::ClusterConfig#connect_timeout` and `#write_timeout`

### DIFF
--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -69,8 +69,16 @@ class RedisClient
       "#<#{self.class.name} #{startup_nodes.values.map { |v| v.reject { |k| k == :command_builder } }}>"
     end
 
+    def connect_timeout
+      @client_config[:connect_timeout] || @client_config[:timeout] || ::RedisClient::Config::DEFAULT_TIMEOUT
+    end
+
     def read_timeout
       @client_config[:read_timeout] || @client_config[:timeout] || ::RedisClient::Config::DEFAULT_TIMEOUT
+    end
+
+    def write_timeout
+      @client_config[:write_timeout] || @client_config[:timeout] || ::RedisClient::Config::DEFAULT_TIMEOUT
     end
 
     def new_pool(size: 5, timeout: 5, **kwargs)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -24,7 +24,9 @@ class RedisClient
 
       def test_config
         refute_nil @client.config
+        refute_nil @client.config.connect_timeout
         refute_nil @client.config.read_timeout
+        refute_nil @client.config.write_timeout
       end
 
       def test_inspect


### PR DESCRIPTION
I'm working on adding redis-clustering support to https://github.com/ParentSquare/faulty, and found a discrepancy between `RedisClient::Config` and `RedisClient::ClusterConfig` in that not all timeout configurations are exposed publicly. I understand that there probably isn't a requirement for them to be consistent, so this is more of a feature request and PR to add them, unless there's a good reason not to?

Ref: https://github.com/redis-rb/redis-client/blob/2621cc2e9fd890d97206dc2beb7131dbe2e35498/lib/redis_client/config.rb#L16