### PR TITLE
fix: pubsub worker stuck in jruby

### DIFF
--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -35,22 +35,27 @@ class RedisClient
           # It is a fixed size but we can modify the size with some environment variables.
           # So it consumes memory 1 MB multiplied a number of workers.
           Thread.new(client, queue, nil) do |pubsub, q, prev_err|
-            loop do
-              q << pubsub.next_event
-              prev_err = nil
-            rescue StandardError => e
-              next sleep 0.005 if e.instance_of?(prev_err.class) && e.message == prev_err&.message
+            Thread.handle_interrupt(WORKER_INTERRUPTION_OPTS) do
+              loop do
+                q << pubsub.next_event
+                prev_err = nil
+              rescue StandardError => e
+                next sleep 0.005 if e.instance_of?(prev_err.class) && e.message == prev_err&.message
 
-              q << e
-              prev_err = e
+                q << e
+                prev_err = e
+              end
             end
+          rescue IOError => e
+            # stream closed in another thread
           end
         end
       end
 
+      WORKER_INTERRUPTION_OPTS = { IOError => :never }.freeze
       BUF_SIZE = Integer(ENV.fetch('REDIS_CLIENT_PUBSUB_BUF_SIZE', 1024))
 
-      private_constant :BUF_SIZE
+      private_constant :WORKER_INTERRUPTION_OPTS, :BUF_SIZE
 
       def initialize(router, command_builder)
         @router = router


### PR DESCRIPTION
```
$ jstack -l PID
```

```
"Ruby-0-Thread-110: /home/kasuga/vcs/redis-cluster-client/lib/redis_client/cluster/pub_sub.rb:37" #200 [297874] daemon prio=5 os_prio=0 cpu=2951.28ms elapsed=146.67s tid=0x000076070863b5a0 nid=297874 runnable  [0x00007605305fe000]
   java.lang.Thread.State: TIMED_WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@23/Native Method)
        - parking to wait for  <0x000000070c173b88> (a java.util.concurrent.Semaphore$NonfairSync)
        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@23/LockSupport.java:269)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@23/AbstractQueuedSynchronizer.java:756)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(java.base@23/AbstractQueuedSynchronizer.java:1126)
        at java.util.concurrent.Semaphore.tryAcquire(java.base@23/Semaphore.java:415)
        at org.jruby.RubyThread$SleepTask2.run(org.jruby.dist/RubyThread.java:1735)
        at org.jruby.RubyThread$SleepTask2.run(org.jruby.dist/RubyThread.java:1722)
        at org.jruby.RubyThread.executeTask(org.jruby.dist/RubyThread.java:1791)
        at org.jruby.RubyThread.executeTaskBlocking(org.jruby.dist/RubyThread.java:1765)
        at org.jruby.RubyThread.sleep(org.jruby.dist/RubyThread.java:1609)
        at org.jruby.RubyKernel.sleepCommon(org.jruby.dist/RubyKernel.java:899)
        at org.jruby.RubyKernel.sleep(org.jruby.dist/RubyKernel.java:884)
        at java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.base@23/DirectMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ac800.invoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.DelegatingMethodHandle$Holder.delegate(java.base@23/DelegatingMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad800.guard(java.base@23/LambdaForm$MH)
        at java.lang.invoke.DelegatingMethodHandle$Holder.delegate(java.base@23/DelegatingMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad800.guard(java.base@23/LambdaForm$MH)
        at java.lang.invoke.Invokers$Holder.linkToCallSite(java.base@23/Invokers$Holder)
        at home.kasuga.vcs.redis_minus_cluster_minus_client.lib.redis_client.cluster.pub_sub.️   {} spawn_worker #1(/home/kasuga/vcs/redis-cluster-client/lib/redis_client/cluster/pub_sub.rb:42)
        at java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.base@23/DirectMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f2dd800.invoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@23/Invokers$Holder)
        at org.jruby.runtime.CompiledIRBlockBody.yieldDirect(org.jruby.dist/CompiledIRBlockBody.java:151)
        at org.jruby.runtime.IRBlockBody.yieldSpecific(org.jruby.dist/IRBlockBody.java:74)
        at org.jruby.runtime.Block.yieldSpecific(org.jruby.dist/Block.java:160)
        at org.jruby.RubyKernel.loop(org.jruby.dist/RubyKernel.java:1657)
        at java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.base@23/DirectMethodHandle$Holder)
        at java.lang.invoke.DelegatingMethodHandle$Holder.reinvoke_L(java.base@23/DelegatingMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0d6c00.invoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad400.reinvoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad800.guard(java.base@23/LambdaForm$MH)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad400.reinvoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0ad800.guard(java.base@23/LambdaForm$MH)
        at java.lang.invoke.Invokers$Holder.linkToCallSite(java.base@23/Invokers$Holder)
        at home.kasuga.vcs.redis_minus_cluster_minus_client.lib.redis_client.cluster.pub_sub.️   {} spawn_worker #0(/home/kasuga/vcs/redis-cluster-client/lib/redis_client/cluster/pub_sub.rb:38)
        at java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.base@23/DirectMethodHandle$Holder)
        at java.lang.invoke.LambdaForm$MH/0x000076068f0b0000.invoke(java.base@23/LambdaForm$MH)
        at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@23/Invokers$Holder)
        at org.jruby.runtime.CompiledIRBlockBody.callDirect(org.jruby.dist/CompiledIRBlockBody.java:141)
        at org.jruby.runtime.MixedModeIRBlockBody.callDirect(org.jruby.dist/MixedModeIRBlockBody.java:105)
        at org.jruby.runtime.IRBlockBody.call(org.jruby.dist/IRBlockBody.java:66)
        at org.jruby.runtime.IRBlockBody.call(org.jruby.dist/IRBlockBody.java:60)
        at org.jruby.runtime.Block.call(org.jruby.dist/Block.java:146)
        at org.jruby.RubyProc.call(org.jruby.dist/RubyProc.java:359)
        at org.jruby.internal.runtime.RubyRunnable.run(org.jruby.dist/RubyRunnable.java:122)
        at java.lang.Thread.runWith(java.base@23/Thread.java:1588)
        at java.lang.Thread.run(java.base@23/Thread.java:1575)
```