### PR TITLE
fix: interruption handling for worker threads

### DIFF
--- a/lib/redis_client/cluster/concurrent_worker/pooled.rb
+++ b/lib/redis_client/cluster/concurrent_worker/pooled.rb
@@ -11,8 +11,8 @@ class RedisClient
       # So it consumes memory 1 MB multiplied a number of workers.
       class Pooled
         IO_ERROR_NEVER = { IOError => :never }.freeze
-        IO_ERROR_ON_BLOCKING = { IOError => :on_blocking }.freeze
-        private_constant :IO_ERROR_NEVER, :IO_ERROR_ON_BLOCKING
+        IO_ERROR_IMMEDIATE = { IOError => :immediate }.freeze
+        private_constant :IO_ERROR_NEVER, :IO_ERROR_IMMEDIATE
 
         def initialize(size:)
           raise ArgumentError, "size must be positive: #{size}" unless size.positive?
@@ -73,7 +73,7 @@ class RedisClient
           Thread.new(@q) do |q|
             Thread.handle_interrupt(IO_ERROR_NEVER) do
               loop do
-                Thread.handle_interrupt(IO_ERROR_ON_BLOCKING) do
+                Thread.handle_interrupt(IO_ERROR_IMMEDIATE) do
                   q.pop.exec
                 end
               end


### PR DESCRIPTION
Although I'm not familiar with internals of JRuby and TruffleRuby, they need strict implementation for concurrency because they have none of the global interpreter lock. I think they provide us some signs of potentially bugs for our multi-threading implementation.

* #438
* #440
* #442
* #444

```
[engine] WARNING: 3 threads did not reach the synchronous ThreadLocalAction kill other threads for shutdown 57b8d3a7 in 60 seconds. When using virtual threads this may be due to the issue that once more than Runtime.availableProcessors() virtual threads are pinned and waiting for each other, no virtual threads can progress (JDK-8334304). Cancelling this ThreadLocalAction to unblock. Use --engine.SynchronousThreadLocalActionPrintStackTraces=true to print thread stacktraces.
truffleruby: an exception escaped out of the interpreter - this is an implementation bug
org.graalvm.polyglot.PolyglotException: java.util.concurrent.CancellationException
	at org.graalvm.truffle/com.oracle.truffle.api.impl.ThreadLocalHandshake$Handshake.get(ThreadLocalHandshake.java:502)
	at org.graalvm.truffle/com.oracle.truffle.api.impl.ThreadLocalHandshake$Handshake.get(ThreadLocalHandshake.java:295)
	at org.graalvm.ruby/org.truffleruby.language.SafepointManager.lambda$pauseAllThreadsAndExecute$0(SafepointManager.java:57)
	at org.graalvm.truffle/com.oracle.truffle.api.impl.ThreadLocalHandshake$TruffleSafepointImpl.setBlockedBoundary(ThreadLocalHandshake.java:881)
	at org.graalvm.truffle/com.oracle.truffle.api.impl.ThreadLocalHandshake$TruffleSafepointImpl.setBlocked(ThreadLocalHandshake.java:852)
	at org.graalvm.truffle/com.oracle.truffle.api.TruffleSafepoint.setBlockedThreadInterruptible(TruffleSafepoint.java:339)
	at org.graalvm.ruby/org.truffleruby.language.SafepointManager.pauseAllThreadsAndExecute(SafepointManager.java:55)
	at org.graalvm.ruby/org.truffleruby.core.thread.ThreadManager.doKillOtherThreads(ThreadManager.java:636)
	at org.graalvm.ruby/org.truffleruby.core.thread.ThreadManager.killAndWaitOtherThreads(ThreadManager.java:613)
	at org.graalvm.ruby/org.truffleruby.RubyContext.finalizeContext(RubyContext.java:488)
	at org.graalvm.ruby/org.truffleruby.RubyLanguage.finalizeContext(RubyLanguage.java:572)
	at org.graalvm.ruby/org.truffleruby.RubyLanguage.finalizeContext(RubyLanguage.java:156)
	at org.graalvm.truffle/com.oracle.truffle.api.LanguageAccessor$LanguageImpl.finalizeContext(LanguageAccessor.java:333)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotLanguageContext.finalizeContext(PolyglotLanguageContext.java:403)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.finalizeContext(PolyglotContextImpl.java:3468)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.finishClose(PolyglotContextImpl.java:2979)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.closeImpl(PolyglotContextImpl.java:2887)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.closeAndMaybeWait(PolyglotContextImpl.java:2039)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.close(PolyglotContextImpl.java:1972)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextDispatch.close(PolyglotContextDispatch.java:72)
	at org.graalvm.polyglot/org.graalvm.polyglot.Context.close(Context.java:887)
	at org.graalvm.polyglot/org.graalvm.polyglot.Context.close(Context.java:914)
	at org.graalvm.ruby.launcher/org.truffleruby.launcher.RubyLauncher.runContext(RubyLauncher.java:365)
	at org.graalvm.ruby.launcher/org.truffleruby.launcher.RubyLauncher.runRubyMain(RubyLauncher.java:296)
	at org.graalvm.ruby.launcher/org.truffleruby.launcher.RubyLauncher.launch(RubyLauncher.java:171)
	at org.graalvm.launcher/org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:305)
	at org.graalvm.launcher/org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:125)
	at org.graalvm.launcher/org.graalvm.launcher.AbstractLanguageLauncher.runLauncher(AbstractLanguageLauncher.java:173)
	Suppressed: Attached Guest Language Frames (0)
Internal GraalVM error, please report at https://github.com/oracle/graal/issues/.
```