### PR TITLE
ci: exclude an execution of a portion of jobs from regular test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -290,7 +290,7 @@ jobs:
         run: docker compose --progress quiet -f $DOCKER_COMPOSE_FILE down || true
   massive:
     name: Massive Cluster
-    if: github.event_name != 'schedule' || github.repository == 'redis-rb/redis-cluster-client'
+    if: github.event_name == 'schedule' && github.repository == 'redis-rb/redis-cluster-client'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Given that takes some time, no need to be executed in every time.