### PR TITLE
ci: workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@
 #
 # @see https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/redis-rb/redis-cluster-client/security/code-scanning/6](https://github.com/redis-rb/redis-cluster-client/security/code-scanning/6)

In general, the fix is to add an explicit `permissions:` block limiting the `GITHUB_TOKEN` to the least privileges required. Since none of the shown jobs perform write operations on the repository or interact with issues/PRs, `contents: read` is a safe minimal permission. Defining this at the workflow root will apply to all jobs that do not override it.

The best fix without changing existing functionality is to add a single workflow-level `permissions:` block immediately under the `name: Test` (or directly under `on:` if you prefer that style). This will constrain the token for `main`, `lint`, `nat-ted-env`, `ips`, `profiling`, and `massive` without modification to individual jobs, including the one highlighted by CodeQL. No extra imports or external dependencies are required; this is pure GitHub Actions YAML configuration.

Concretely, edit `.github/workflows/test.yaml` near the top: after line 9 (`name: Test`), insert:

```yaml
permissions:
  contents: read
```

All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
