### PR TITLE
perf: improve hashtag extraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec name: 'redis-cluster-client'
 
 gem 'async-redis', platform: :mri
+gem 'benchmark'
 gem 'benchmark-ips'
 gem 'hiredis-client', '~> 0.6'
 gem 'irb'

--- a/lib/redis_client/cluster/key_slot_converter.rb
+++ b/lib/redis_client/cluster/key_slot_converter.rb
@@ -70,7 +70,7 @@ class RedisClient
         e = key.index(RIGHT_BRACKET, s + 1)
         return EMPTY_STRING if e.nil?
 
-        key[s + 1..e - 1]
+        s + 1 < e ? key[s + 1, e - s - 1] : EMPTY_STRING
       end
 
       def hash_tag_included?(key)

--- a/test/ips_hashtag_extraction.rb
+++ b/test/ips_hashtag_extraction.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'redis_cluster_client'
+
+module HashtagExtraction
+  module_function
+
+  def run
+    key = 'aaaa{aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}aaaaaaaa'
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+      x.report('Hashtag Extraction') do
+        ::RedisClient::Cluster::KeySlotConverter.extract_hash_tag(key)
+      end
+
+      x.compare!
+    end
+  end
+end
+
+HashtagExtraction.run


### PR DESCRIPTION
### Before
```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
Warming up --------------------------------------
  Hashtag Extraction   158.668k i/100ms
Calculating -------------------------------------
  Hashtag Extraction      1.607M (± 1.0%) i/s  (622.45 ns/i) -      8.092M in   5.037486s
```

### After
```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
Warming up --------------------------------------
  Hashtag Extraction   203.693k i/100ms
Calculating -------------------------------------
  Hashtag Extraction      2.019M (± 0.8%) i/s  (495.41 ns/i) -     10.185M in   5.045921s
```