### PR TITLE
fix: reduce wasted retries and mitigate thundering-herd problem on cluster-state change

### DIFF
--- a/bin/reload_bomb.rb
+++ b/bin/reload_bomb.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'logger'
+require 'bundler/setup'
+require 'redis_cluster_client'
+
+logger = Logger.new($stdout)
+
+pids = Array.new(10) do
+  Process.fork do
+    Signal.trap(:INT, 'IGNORE')
+    nodes = (6379..6384).map { |port| "redis://127.0.0.1:#{port}" }.freeze
+    client = RedisClient.cluster(nodes: nodes, connect_with_original_config: true).new_client
+    Signal.trap(:TERM) do
+      client.close
+      Process.exit
+    end
+
+    loop do
+      logger.info("#{Process.pid}: reloaded") if client.send(:router).renew_cluster_state
+    rescue StandardError => e
+      logger.error("#{Process.pid}: #{e.message}")
+    ensure
+      sleep 0.01
+    end
+  end
+end
+
+Signal.trap(:INT) do
+  pids.each { |pid| Process.kill(:TERM, pid) }
+end
+
+pids.each do |pid|
+  Process.waitpid2(pid)
+  logger.info("#{pid}: child process closed")
+end
+
+logger.info("#{Process.pid}: parent process closed")
+Process.exit

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -24,7 +24,7 @@ class RedisClient
       ROLE_FLAGS = %w[master slave].freeze
       EMPTY_ARRAY = [].freeze
       EMPTY_HASH = {}.freeze
-      STATE_REFRESH_INTERVAL = (3..10).freeze
+      JITTER_RANGE = (3_000_000..13_000_000).freeze # micro seconds
 
       private_constant :USE_CHAR_ARRAY_SLOT, :SLOT_SIZE, :MIN_SLOT, :MAX_SLOT,
                        :DEAD_FLAGS, :ROLE_FLAGS, :EMPTY_ARRAY, :EMPTY_HASH
@@ -106,8 +106,7 @@ class RedisClient
         @topology = klass.new(pool, @concurrent_worker, **kwargs)
         @config = config
         @mutex = Mutex.new
-        @last_reloaded_at = nil
-        @reload_times = 0
+        @next_reload_time = nil
         @random = Random.new
       end
 
@@ -203,16 +202,12 @@ class RedisClient
         @mutex.unlock if @mutex.owned?
       end
 
-      def reload!
+      def try_reload!
         with_reload_lock do
-          with_startup_clients(@config.max_startup_sample) do |startup_clients|
-            @node_info = refetch_node_info_list(startup_clients)
-            @node_configs = @node_info.to_h do |node_info|
-              [node_info.node_key, @config.client_config_for_node(node_info.node_key)]
+          with_reload_jitter do
+            with_startup_clients(@config.max_startup_sample) do |clients|
+              reload!(clients)
             end
-            @slots = build_slot_node_mappings(@node_info)
-            @replications = build_replication_mappings(@node_info)
-            @topology.process_topology_update!(@replications, @node_configs)
           end
         end
       end
@@ -432,6 +427,17 @@ class RedisClient
         "#{hostname}:#{port}"
       end
 
+      def reload!(clients)
+        @node_info = refetch_node_info_list(clients)
+        @node_configs = @node_info.to_h do |node_info|
+          [node_info.node_key, @config.client_config_for_node(node_info.node_key)]
+        end
+        @slots = build_slot_node_mappings(@node_info)
+        @replications = build_replication_mappings(@node_info)
+        @topology.process_topology_update!(@replications, @node_configs)
+        true
+      end
+
       def with_startup_clients(count) # rubocop:disable Metrics/AbcSize
         if @config.connect_with_original_config
           # If connect_with_original_config is set, that means we need to build actual client objects
@@ -457,34 +463,40 @@ class RedisClient
         end
       end
 
+      def with_reload_jitter
+        return false unless @next_reload_time.nil? || obtain_current_time >= @next_reload_time
+
+        result = yield
+        @next_reload_time = obtain_current_time + @random.rand(JITTER_RANGE)
+        result
+      end
+
       def with_reload_lock
-        # What should happen with concurrent calls #reload? This is a realistic possibility if the cluster goes into
+        # What should happen with concurrent calls #try_reload! This is a realistic possibility if the cluster goes into
         # a CLUSTERDOWN state, and we're using a pooled backend. Every thread will independently discover this, and
-        # call reload!.
-        # For now, if a reload is in progress, wait for that to complete, and consider that the same as us having
-        # performed the reload.
-        # Probably in the future we should add a circuit breaker to #reload itself, and stop trying if the cluster is
+        # call #try_reload!.
+        # For now, if a reload is in progress by a thread, the other threads do not wait for that to complete, and
+        # they throw an error.
+        # Probably in the future we should add a circuit breaker to #try_reload! itself, and stop trying if the cluster is
         # obviously not working.
-        wait_start = obtain_current_time
-        @mutex.synchronize do
-          return if @last_reloaded_at && @last_reloaded_at > wait_start
+        return false unless @mutex.try_lock
 
-          if @last_reloaded_at && @reload_times > 1
-            # Mitigate load of servers by naive logic. Don't sleep with exponential backoff.
-            now = obtain_current_time
-            elapsed = @last_reloaded_at + @random.rand(STATE_REFRESH_INTERVAL) * 1_000_000
-            return if now < elapsed
-          end
-
-          r = yield
-          @last_reloaded_at = obtain_current_time
-          @reload_times += 1
-          r
-        end
+        yield
+      ensure
+        @mutex.unlock if @mutex.owned?
       end
 
       def obtain_current_time
         Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
+      end
+
+      def bypass_reload!
+        # DO NOT USE THIS METHOD
+        with_reload_lock do
+          with_startup_clients(@config.max_startup_sample) do |clients|
+            reload!(clients)
+          end
+        end
       end
     end
   end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -84,7 +84,7 @@ class RedisClient
         @pool = pool
         @client_kwargs = kwargs
         @node = ::RedisClient::Cluster::Node.new(concurrent_worker, config: config, pool: pool, **kwargs)
-        @node.reload!
+        @node.try_reload!
         @command = ::RedisClient::Cluster::Command.load(@node.replica_clients.shuffle, slow_command_timeout: config.slow_command_timeout)
         @command_builder = @config.command_builder
       rescue ::RedisClient::Cluster::InitialSetupError => e
@@ -158,16 +158,15 @@ class RedisClient
             retry
           end
         elsif e.message.start_with?('CLUSTERDOWN')
-          renew_cluster_state
-          retry if retry_count >= 0
+          retry if renew_cluster_state && retry_count >= 0
         end
 
         raise
       rescue ::RedisClient::ConnectionError => e
         raise unless ::RedisClient::Cluster::ErrorIdentification.client_owns_error?(e, node)
+        raise unless renew_cluster_state
 
         retry_count -= 1
-        renew_cluster_state
 
         if retry_count >= 0
           # Find the node to use for this command - if this fails for some reason, though, re-use
@@ -179,7 +178,6 @@ class RedisClient
           retry
         end
 
-        retry if retry_count >= 0
         raise
       end
 
@@ -293,9 +291,9 @@ class RedisClient
       end
 
       def renew_cluster_state
-        @node.reload!
+        @node.try_reload!
       rescue ::RedisClient::Cluster::InitialSetupError
-        # ignore
+        false
       end
 
       def close
@@ -332,15 +330,15 @@ class RedisClient
         raise ::RedisClient::Cluster::AmbiguousNodeError.from_command(command.first).with_config(@config)
       end
 
-      def send_wait_command(method, command, args, retry_count: 1, &block) # rubocop:disable Metrics/AbcSize
+      def send_wait_command(method, command, args, retry_count: 1, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
         @node.call_primaries(method, command, args).select { |r| r.is_a?(Integer) }.sum.then(&TSF.call(block))
       rescue ::RedisClient::Cluster::ErrorCollection => e
         raise if e.errors.any?(::RedisClient::CircuitBreaker::OpenCircuitError)
         raise if retry_count <= 0
         raise if e.errors.values.none? { |err| err.message.include?('WAIT cannot be used with replica instances') }
+        raise unless renew_cluster_state
 
         retry_count -= 1
-        renew_cluster_state
         retry
       end
 
@@ -499,10 +497,9 @@ class RedisClient
       def handle_node_reload_error(retry_count: 1)
         yield
       rescue ::RedisClient::Cluster::Node::ReloadNeeded
-        raise ::RedisClient::Cluster::NodeMightBeDown.new.with_config(@config) if retry_count <= 0
+        raise ::RedisClient::Cluster::NodeMightBeDown.new.with_config(@config) if retry_count <= 0 || !renew_cluster_state
 
         retry_count -= 1
-        renew_cluster_state
         retry
       end
     end

--- a/test/redis_client/cluster/node/testing_topology_mixin.rb
+++ b/test/redis_client/cluster/node/testing_topology_mixin.rb
@@ -13,7 +13,7 @@ class RedisClient
           }.merge(kwargs))
           concurrent_worker = ::RedisClient::Cluster::ConcurrentWorker.create
           ::RedisClient::Cluster::Node.new(concurrent_worker, pool: pool, config: config).tap do |node|
-            node.reload!
+            node.try_reload!
             @test_nodes ||= []
             @test_nodes << node
           end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -27,8 +27,8 @@ class RedisClient
       MAX_STARTUP_SAMPLE = Integer(ENV.fetch('REDIS_CLIENT_MAX_STARTUP_SAMPLE', 3))
 
       def setup
-        @test_node = make_node.tap(&:reload!)
-        @test_node_with_scale_read = make_node(replica: true).tap(&:reload!)
+        @test_node = make_node.tap(&:try_reload!)
+        @test_node_with_scale_read = make_node(replica: true).tap(&:try_reload!)
         @test_node_info_list = @test_node.instance_variable_get(:@node_info)
       end
 
@@ -735,7 +735,7 @@ class RedisClient
         test_node = make_node(replica: true, capture_buffer: capture_buffer)
 
         capture_buffer.clear
-        test_node.reload!
+        test_node.try_reload!
 
         # It should have reloaded by calling CLUSTER NODES on three of the startup nodes
         cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
@@ -746,7 +746,7 @@ class RedisClient
 
         # If we reload again, it should NOT change the redis client instances we have.
         original_client_ids = test_node.to_a.map(&:object_id).to_set
-        test_node.reload!
+        test_node.try_reload!
         new_client_ids = test_node.to_a.map(&:object_id).to_set
         assert_equal original_client_ids, new_client_ids
       end
@@ -761,13 +761,13 @@ class RedisClient
           capture_buffer: capture_buffer
         )
 
-        test_node.reload!
+        test_node.try_reload!
         # After reloading the first time, our Node object knows about all hosts, despite only starting with one:
         assert_equal TEST_NUMBER_OF_NODES, test_node.to_a.size
 
         # When we reload, it will only call CLUSTER NODES against a single node, the bootstrap node.
         capture_buffer.clear
-        test_node.reload!
+        test_node.send(:bypass_reload!)
 
         cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
         assert_equal 1, cluster_node_cmds.size
@@ -779,7 +779,7 @@ class RedisClient
         test_node = make_node(replica: true, capture_buffer: capture_buffer, max_startup_sample: 1)
 
         capture_buffer.clear
-        test_node.reload!
+        test_node.try_reload!
 
         # It should have reloaded by calling CLUSTER NODES on one of the startup nodes
         cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
@@ -790,7 +790,7 @@ class RedisClient
 
         # If we reload again, it should NOT change the redis client instances we have.
         original_client_ids = test_node.to_a.map(&:object_id).to_set
-        test_node.reload!
+        test_node.try_reload!
         new_client_ids = test_node.to_a.map(&:object_id).to_set
         assert_equal original_client_ids, new_client_ids
       end
@@ -809,8 +809,8 @@ class RedisClient
         end)
 
         capture_buffer.clear
-        t1 = Thread.new { test_node.reload! }
-        t2 = Thread.new { test_node.reload! }
+        t1 = Thread.new { test_node.try_reload! }
+        t2 = Thread.new { test_node.try_reload! }
         [t1, t2].each(&:join)
 
         # We should only have reloaded once, which is to say, we only called CLUSTER NODES command MAX_STARTUP_SAMPLE

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -864,9 +864,7 @@ class RedisClient
           connect_with_original_config: true,
           **TEST_GENERIC_OPTIONS.merge(
             circuit_breaker: {
-              # Also important - the retry_count on resharding errors is set to 3, so we have to allow at lest
-              # that many errors to avoid tripping the breaker in the first call.
-              error_threshold: 4,
+              error_threshold: 1,
               error_timeout: 60,
               success_threshold: 10
             }


### PR DESCRIPTION
* On multithreaded clients, they do not need to wait for the cluster state to be renewed; they should throw an error instead to prevent overflow of the request queue in OLTP.
  * It is guaranteed that only one thread can refetch the latest cluster state at a time using a mutex.
* On multiprocessed clients, jitter windows are needed to fetch the latest cluster state.
  * There is a trade-off between the speed of recovery on the client side and the load on the server because of the following slow commands:
    * CLUSTER NODES
    * CLUSTER SLOTS
    * CLUSTER SHARDS
    * COMMAND
  * Also, we have a configurable value, `max_startup_sample`, for the quorum.
    * https://github.com/redis-rb/redis-cluster-client/blob/3247d8e955eba820c9bb89ddd88170a4ee5487d5/lib/redis_client/cluster_config.rb#L26-L27
  * #238
  * #241
  * #368