### PR TITLE
fix: use CLUSTER SHARDS instead of CLUSTER NODES

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -46,7 +46,7 @@ class RedisClient
         end
 
         def serialize(str)
-          str << id << node_key << role << primary_id << config_epoch
+          str << id << node_key << role << primary_id
         end
       end
 
@@ -307,12 +307,11 @@ class RedisClient
           work_group.push(i, raw_client) do |client|
             regular_timeout = client.read_timeout
             client.read_timeout = @config.slow_command_timeout > 0.0 ? @config.slow_command_timeout : regular_timeout
-            reply = client.call_once('cluster', 'nodes')
-            client.read_timeout = regular_timeout
-            parse_cluster_node_reply(reply)
+            fetch_cluster_state(client)
           rescue StandardError => e
             e
           ensure
+            client.read_timeout = regular_timeout
             client&.close
           end
         end
@@ -340,6 +339,16 @@ class RedisClient
         end
 
         grouped.max_by { |_, v| v.size }[1].first
+      end
+
+      def fetch_cluster_state(client)
+        reply = client.call_once('cluster', 'shards')
+        parse_cluster_shards_reply(reply)
+      rescue ::RedisClient::CommandError => e
+        raise unless e.message.start_with?('ERR unknown subcommand')
+
+        reply = client.call_once('cluster', 'nodes')
+        parse_cluster_node_reply(reply)
       end
 
       def parse_cluster_node_reply(reply) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -385,11 +394,11 @@ class RedisClient
               id: id,
               node_key: NodeKey.build_from_host_port(ip, arr[1]),
               role: role,
-              primary_id: role == 'master' ? nil : primary_id,
+              primary_id: role == 'master' ? '' : primary_id,
               slots: role == 'master' ? slots : EMPTY_ARRAY
             )
           end
-        end.freeze
+        end
       end
 
       def parse_cluster_shards_reply(reply) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -406,11 +415,11 @@ class RedisClient
               id: node.fetch('id'),
               node_key: NodeKey.build_from_host_port(ip, node['port'] || node['tls-port']),
               role: role == 'master' ? role : 'slave',
-              primary_id: role == 'master' ? nil : primary_id,
+              primary_id: role == 'master' ? '' : primary_id,
               slots: role == 'master' ? shard.fetch('slots').each_slice(2).to_a.freeze : EMPTY_ARRAY
             )
           end
-        end.freeze
+        end
       end
 
       # As redirection node_key is dependent on `cluster-preferred-endpoint-type` config,

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -28,7 +28,8 @@ class RedisClient
       JITTER_WINDOW = (3_000_000...10_000_000).freeze # micro seconds
 
       private_constant :USE_CHAR_ARRAY_SLOT, :SLOT_SIZE, :MIN_SLOT, :MAX_SLOT,
-                       :DEAD_FLAGS, :ROLE_FLAGS, :EMPTY_ARRAY, :EMPTY_HASH, :EMPTY_STRING
+                       :DEAD_FLAGS, :ROLE_FLAGS, :EMPTY_ARRAY, :EMPTY_HASH, :EMPTY_STRING,
+                       :JITTER_WINDOW
 
       ReloadNeeded = Class.new(::RedisClient::Cluster::Error)
 

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -24,10 +24,11 @@ class RedisClient
       ROLE_FLAGS = %w[master slave].freeze
       EMPTY_ARRAY = [].freeze
       EMPTY_HASH = {}.freeze
+      EMPTY_STRING = ''
       JITTER_WINDOW = (3_000_000...10_000_000).freeze # micro seconds
 
       private_constant :USE_CHAR_ARRAY_SLOT, :SLOT_SIZE, :MIN_SLOT, :MAX_SLOT,
-                       :DEAD_FLAGS, :ROLE_FLAGS, :EMPTY_ARRAY, :EMPTY_HASH
+                       :DEAD_FLAGS, :ROLE_FLAGS, :EMPTY_ARRAY, :EMPTY_HASH, :EMPTY_STRING
 
       ReloadNeeded = Class.new(::RedisClient::Cluster::Error)
 
@@ -345,7 +346,7 @@ class RedisClient
         reply = client.call_once('cluster', 'shards')
         parse_cluster_shards_reply(reply)
       rescue ::RedisClient::CommandError => e
-        raise unless e.message.start_with?('ERR unknown subcommand')
+        raise unless e.message.start_with?('ERR Unknown subcommand')
 
         reply = client.call_once('cluster', 'nodes')
         parse_cluster_node_reply(reply)
@@ -394,7 +395,7 @@ class RedisClient
               id: id,
               node_key: NodeKey.build_from_host_port(ip, arr[1]),
               role: role,
-              primary_id: role == 'master' ? '' : primary_id,
+              primary_id: role == 'master' ? EMPTY_STRING : primary_id,
               slots: role == 'master' ? slots : EMPTY_ARRAY
             )
           end
@@ -415,7 +416,7 @@ class RedisClient
               id: node.fetch('id'),
               node_key: NodeKey.build_from_host_port(ip, node['port'] || node['tls-port']),
               role: role == 'master' ? role : 'slave',
-              primary_id: role == 'master' ? '' : primary_id,
+              primary_id: role == 'master' ? EMPTY_STRING : primary_id,
               slots: role == 'master' ? shard.fetch('slots').each_slice(2).to_a.freeze : EMPTY_ARRAY
             )
           end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -738,7 +738,8 @@ class RedisClient
         test_node.try_reload!
 
         # It should have reloaded by calling CLUSTER NODES on three of the startup nodes
-        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
+        subcmd = TEST_REDIS_MAJOR_VERSION >= 7 ? 'shards' : 'nodes'
+        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == ['cluster', subcmd] }
         assert_equal MAX_STARTUP_SAMPLE, cluster_node_cmds.size
 
         # It should have connected to all of the clients.
@@ -769,7 +770,8 @@ class RedisClient
         capture_buffer.clear
         test_node.send(:bypass_reload!)
 
-        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
+        subcmd = TEST_REDIS_MAJOR_VERSION >= 7 ? 'shards' : 'nodes'
+        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == ['cluster', subcmd] }
         assert_equal 1, cluster_node_cmds.size
         assert_equal bootstrap_node, cluster_node_cmds.first.server_url
       end
@@ -782,7 +784,8 @@ class RedisClient
         test_node.try_reload!
 
         # It should have reloaded by calling CLUSTER NODES on one of the startup nodes
-        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
+        subcmd = TEST_REDIS_MAJOR_VERSION >= 7 ? 'shards' : 'nodes'
+        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == ['cluster', subcmd] }
         assert_equal 1, cluster_node_cmds.size
 
         # It should have connected to all of the clients.
@@ -815,7 +818,8 @@ class RedisClient
 
         # We should only have reloaded once, which is to say, we only called CLUSTER NODES command MAX_STARTUP_SAMPLE
         # times
-        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == %w[cluster nodes] }
+        subcmd = TEST_REDIS_MAJOR_VERSION >= 7 ? 'shards' : 'nodes'
+        cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == ['cluster', subcmd] }
         assert_equal MAX_STARTUP_SAMPLE, cluster_node_cmds.size
       end
     end

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -304,15 +304,15 @@ class RedisClient
         ]
 
         want = [
-          { id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb', node_key: '10.10.1.6:6379', role: 'master', primary_id: nil,
+          { id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb', node_key: '10.10.1.6:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[0, 5460]] },
           { id: 'b60c0672f257c01d76f27eacded14b6e6f4f990e', node_key: '10.10.1.5:6379', role: 'slave', primary_id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] },
-          { id: '712b9a6656b38a5e002244903853fccb4d1eef4b', node_key: '10.10.1.4:6379', role: 'master', primary_id: nil,
+          { id: '712b9a6656b38a5e002244903853fccb4d1eef4b', node_key: '10.10.1.4:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[5461, 10_922]] },
           { id: '7038691c545e7caa9147030ecfb4acf1eaad0552', node_key: '10.10.1.7:6379', role: 'slave', primary_id: '712b9a6656b38a5e002244903853fccb4d1eef4b',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] },
-          { id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082', node_key: '10.10.1.8:6379', role: 'master', primary_id: nil,
+          { id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082', node_key: '10.10.1.8:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[10_923, 16_383]] },
           { id: 'f2f36b472b187c577ccd93dd296e9045f473ae7a', node_key: '10.10.1.3:6379', role: 'slave', primary_id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] }
@@ -397,15 +397,15 @@ class RedisClient
         ]
 
         want = [
-          { id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb', node_key: '10.10.1.6:6379', role: 'master', primary_id: nil,
+          { id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb', node_key: '10.10.1.6:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[0, 5460]] },
           { id: 'b60c0672f257c01d76f27eacded14b6e6f4f990e', node_key: '10.10.1.5:6379', role: 'slave', primary_id: '00c0d00f2a5eda22b2c8a8929ba27b454c4400fb',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] },
-          { id: '712b9a6656b38a5e002244903853fccb4d1eef4b', node_key: '10.10.1.4:6379', role: 'master', primary_id: nil,
+          { id: '712b9a6656b38a5e002244903853fccb4d1eef4b', node_key: '10.10.1.4:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[5461, 10_922]] },
           { id: '7038691c545e7caa9147030ecfb4acf1eaad0552', node_key: '10.10.1.7:6379', role: 'slave', primary_id: '712b9a6656b38a5e002244903853fccb4d1eef4b',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] },
-          { id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082', node_key: '10.10.1.8:6379', role: 'master', primary_id: nil,
+          { id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082', node_key: '10.10.1.8:6379', role: 'master', primary_id: '',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [[10_923, 16_383]] },
           { id: 'f2f36b472b187c577ccd93dd296e9045f473ae7a', node_key: '10.10.1.3:6379', role: 'slave', primary_id: 'ba85d0807043bb40f72bb4e1e8352b029c6e0082',
             ping_sent: nil, pong_recv: nil, config_epoch: nil, link_state: nil, slots: [] }

--- a/test/test_against_cluster_broken.rb
+++ b/test/test_against_cluster_broken.rb
@@ -231,7 +231,7 @@ class TestAgainstClusterBroken < TestingWrapper
 
   def log_metrics
     print "#{@redirect_count.get}, "\
-      "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')}, "\
+      "ClusterShardsCall: #{@captured_commands.count('cluster', 'shards')}, "\
       "ClusterDownError: #{@cluster_down_error_count}\n"
   end
 

--- a/test/test_against_cluster_down.rb
+++ b/test/test_against_cluster_down.rb
@@ -28,7 +28,7 @@ class TestAgainstClusterDown < TestingWrapper
     @threads&.each(&:exit)
     @clients&.each(&:close)
     print "#{@redirect_count.get}, "\
-      "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')}, "\
+      "ClusterShardsCall: #{@captured_commands.count('cluster', 'shards')}, "\
       "ClusterDownError: #{@cluster_down_counter.get} = "
   end
 
@@ -50,7 +50,7 @@ class TestAgainstClusterDown < TestingWrapper
     wait_for_jobs_to_be_stable
 
     refute(@cluster_down_counter.get.zero?, 'Case: cluster down count')
-    refute(@captured_commands.count('cluster', 'nodes').zero?, 'Case: cluster nodes calls')
+    refute(@captured_commands.count('cluster', 'shards').zero?, 'Case: cluster shards calls')
 
     @values_a = @recorders.map { |r| r.get.to_i }
     wait_for_jobs_to_be_stable

--- a/test/test_against_cluster_scale.rb
+++ b/test/test_against_cluster_scale.rb
@@ -34,7 +34,7 @@ module TestAgainstClusterScale
       @client&.close
       @controller&.close
       print "#{@redirect_count.get}, "\
-        "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')}, "\
+        "ClusterShardsCall: #{@captured_commands.count('cluster', 'shards')}, "\
         "ClusterDownError: #{@cluster_down_error_count} = "
     end
 
@@ -64,7 +64,7 @@ module TestAgainstClusterScale
                    .size
       assert_equal(want, got, 'Case: number of nodes')
 
-      refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
+      refute(@captured_commands.count('cluster', 'shards').zero?, @captured_commands.to_a.map(&:command))
     end
 
     def test_02_scale_in
@@ -81,7 +81,7 @@ module TestAgainstClusterScale
                    .size
       assert_equal(want, got, 'Case: number of nodes')
 
-      refute(@captured_commands.count('cluster', 'nodes').zero?, @captured_commands.to_a.map(&:command))
+      refute(@captured_commands.count('cluster', 'shards').zero?, @captured_commands.to_a.map(&:command))
     end
 
     private

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -26,7 +26,7 @@ module TestAgainstClusterState
       @controller&.close
       @client&.close
       print "#{@redirect_count.get}, "\
-        "ClusterNodesCall: #{@captured_commands.count('cluster', 'nodes')} = "
+        "ClusterShardsCall: #{@captured_commands.count('cluster', 'shards')} = "
     end
 
     def test_the_state_of_cluster_resharding


### PR DESCRIPTION
Redis 6 has already reached EOL, so we can simply try CLUSTER SHARDS and fall back to CLUSTER NODES if that fails.
https://redis.io/docs/latest/operate/rs/installing-upgrading/product-lifecycle/

Some clients use different commands depending on the server version in the HELLO command reply. There may be a way to make use of COMMAND command information. It seems that the majority of clients still use the deprecated CLUSTER SLOTS.

| Command | Note |
| -- | -- |
| `CLUSTER NODES` | a huge string reply |
| `CLUSTER SLOTS` | deprecated |
| `CLUSTER SHARDS` | Redis 7+ |

ACL: `+CLUSTER|SHARDS`