### PR TITLE
fix: restore read_timeout when Command.load fails

### DIFF
--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -29,14 +29,17 @@ class RedisClient
           nodes&.each do |node|
             regular_timeout = node.read_timeout
             node.read_timeout = slow_command_timeout > 0.0 ? slow_command_timeout : regular_timeout
-            reply = node.call('command')
-            node.read_timeout = regular_timeout
-            commands = parse_command_reply(reply)
-            cmd = ::RedisClient::Cluster::Command.new(commands)
-            break
-          rescue ::RedisClient::Error => e
-            errors ||= []
-            errors << e
+            begin
+              reply = node.call('command')
+              commands = parse_command_reply(reply)
+              cmd = ::RedisClient::Cluster::Command.new(commands)
+              break
+            rescue ::RedisClient::Error => e
+              errors ||= []
+              errors << e
+            ensure
+              node.read_timeout = regular_timeout
+            end
           end
 
           return cmd unless cmd.nil?

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -29,17 +29,15 @@ class RedisClient
           nodes&.each do |node|
             regular_timeout = node.read_timeout
             node.read_timeout = slow_command_timeout > 0.0 ? slow_command_timeout : regular_timeout
-            begin
-              reply = node.call('command')
-              commands = parse_command_reply(reply)
-              cmd = ::RedisClient::Cluster::Command.new(commands)
-              break
-            rescue ::RedisClient::Error => e
-              errors ||= []
-              errors << e
-            ensure
-              node.read_timeout = regular_timeout
-            end
+            reply = node.call('command')
+            commands = parse_command_reply(reply)
+            cmd = ::RedisClient::Cluster::Command.new(commands)
+            break
+          rescue ::RedisClient::Error => e
+            errors ||= []
+            errors << e
+          ensure
+            node.read_timeout = regular_timeout
           end
 
           return cmd unless cmd.nil?

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -45,6 +45,27 @@ class RedisClient
         assert_equal(TEST_TIMEOUT_SEC, nodes.first.read_timeout)
       end
 
+      def test_load_restores_read_timeout_when_call_raises
+        fake_node_class = Struct.new(:read_timeout, :timeout_writes) do
+          def call(*)
+            raise ::RedisClient::ConnectionError, 'boom'
+          end
+        end
+
+        fake_node = fake_node_class.new(1.0, [])
+        fake_node.define_singleton_method(:read_timeout=) do |value|
+          timeout_writes << value
+          super(value)
+        end
+
+        assert_raises(::RedisClient::Cluster::InitialSetupError) do
+          ::RedisClient::Cluster::Command.load([fake_node], slow_command_timeout: 5.0)
+        end
+
+        assert_equal([5.0, 1.0], fake_node.timeout_writes)
+        assert_in_delta(1.0, fake_node.read_timeout)
+      end
+
       def test_parse_command_reply
         [
           {


### PR DESCRIPTION
## Summary

`Command.load` temporarily replaces each node's `read_timeout` with `slow_command_timeout` while issuing the `COMMAND` request, intending to restore it after. However, when the request raises `RedisClient::Error`, the rescue clause swallows the error and moves on to the next node — without restoring the original timeout. Subsequent normal traffic on that client then runs with the (potentially very long) slow timeout indefinitely.

`Node#refetch_node_info_list` already uses `ensure` for the same pattern; this PR brings `Command.load` in line.

## Test plan

- [x] New unit test `test_load_restores_read_timeout_when_call_raises` verifies the timeout is restored when the call raises
- [x] Existing tests still pass
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a bug audit of this codebase.