### PR TITLE
fix: ensure OptimisticLocking deducts at least one retry on ConnectionError

### DIFF
--- a/lib/redis_client/cluster/optimistic_locking.rb
+++ b/lib/redis_client/cluster/optimistic_locking.rb
@@ -54,7 +54,7 @@ class RedisClient
       rescue ::RedisClient::ConnectionError
         # Deduct the number of retries that happened _inside_ router#handle_redirection from our remaining
         # _external_ retries. Always deduct at least one in case handle_redirection raises without trying the block.
-        retry_count -= [times_block_executed, 1].min
+        retry_count -= [times_block_executed, 1].max
         raise if retry_count < 0
 
         retry

--- a/test/redis_client/cluster/test_optimistic_locking.rb
+++ b/test/redis_client/cluster/test_optimistic_locking.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'testing_helper'
+require 'redis_client/cluster/optimistic_locking'
+
+class RedisClient
+  class Cluster
+    class TestOptimisticLocking < TestingWrapper
+      # A fake router whose inner +handle_redirection+ always raises
+      # +ConnectionError+ before invoking the user block. This mirrors a
+      # persistent connection failure inside +Router#handle_redirection+ that
+      # surfaces before the block can be reached, so +times_block_executed+
+      # stays at 0 in the outer rescue. Each call increments +call_count+ so
+      # the test can bound retry behaviour.
+      class FakeRouter
+        attr_reader :call_count
+
+        def initialize(slot:)
+          @slot = slot
+          @call_count = 0
+        end
+
+        def find_slot_by_key(_key)
+          @slot
+        end
+
+        def find_primary_node_by_slot(_slot)
+          :fake_node
+        end
+
+        def handle_redirection(_node, _command, retry_count:)
+          @call_count += 1
+          # Raise before yielding so +times_block_executed+ stays 0 in the
+          # caller. +retry_count+ is intentionally ignored because the bug
+          # under test is in the OUTER deduction logic, not the inner retry.
+          _ = retry_count
+          raise ::RedisClient::ConnectionError, 'fake connection error'
+        end
+
+        def renew_cluster_state; end
+      end
+
+      def test_handle_redirection_bounds_retries_when_inner_block_never_executes
+        router = FakeRouter.new(slot: 0)
+        locking = ::RedisClient::Cluster::OptimisticLocking.new(router)
+
+        assert_raises(::RedisClient::ConnectionError) do
+          locking.watch(['key']) { |_c, _slot, _asking| flunk('block should never execute') }
+        end
+
+        # +retry_count+ defaults to 1 inside +OptimisticLocking#watch+. With
+        # the fix, every iteration deducts at least 1 from +retry_count+, so
+        # the loop terminates after at most +retry_count + 1+ attempts.
+        # Without the fix this loop is infinite, so the test would hang.
+        assert_operator(router.call_count, :<=, 2,
+                        'Router#handle_redirection must not be invoked more than retry_count + 1 times')
+        assert_operator(router.call_count, :>=, 1,
+                        'Router#handle_redirection must be invoked at least once')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`OptimisticLocking#handle_redirection` rescues `ConnectionError` and deducts retries with `retry_count -= [times_block_executed, 1].min`. The inline comment says *"Always deduct at least one in case handle_redirection raises without trying the block"*, but `.min` does the opposite — when the inner block never executes (`times_block_executed == 0`), it deducts 0 and `retry_count` is unchanged.

Result: if `Router#handle_redirection` raises `ConnectionError` before invoking the block (e.g., persistent connection failure during initial node lookup), the outer rescue spins indefinitely.

This PR changes `.min` to `.max`, which matches the documented intent.

## Test plan

- [x] New unit test bounds the number of retries when the inner path always raises `ConnectionError` before block execution
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a bug audit of this codebase.
