### PR TITLE
fix: throttle reload attempts when reload itself fails

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -479,9 +479,11 @@ class RedisClient
       def with_reload_jitter
         return unless @next_reload_time.nil? || obtain_current_time >= @next_reload_time
 
-        yield
-
-        @next_reload_time = obtain_current_time + @random.rand(JITTER_WINDOW)
+        begin
+          yield
+        ensure
+          @next_reload_time = obtain_current_time + @random.rand(JITTER_WINDOW)
+        end
       end
 
       def with_reload_lock

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -915,6 +915,23 @@ class RedisClient
         cluster_node_cmds = capture_buffer.to_a.select { |c| c.command == ['cluster', subcmd] }
         assert_equal MAX_STARTUP_SAMPLE, cluster_node_cmds.size
       end
+
+      def test_with_reload_jitter_throttles_after_failure
+        @test_node.instance_variable_set(:@next_reload_time, nil)
+
+        assert_raises(StandardError) do
+          @test_node.send(:with_reload_jitter) { raise StandardError, 'fail' }
+        end
+
+        next_reload_time = @test_node.instance_variable_get(:@next_reload_time)
+        refute_nil(next_reload_time, 'next_reload_time should be set after a failed yield')
+        assert_operator(next_reload_time, :>, @test_node.send(:obtain_current_time),
+                        'next_reload_time should be in the future')
+
+        yielded = false
+        @test_node.send(:with_reload_jitter) { yielded = true }
+        refute(yielded, 'block should not be yielded while throttled after a failure')
+      end
     end
     # rubocop:enable Metrics/ClassLength
   end


### PR DESCRIPTION
## Summary

`Node#with_reload_jitter` (introduced in #476 to mitigate thundering-herd) updated `@next_reload_time` only after a successful yield. When the reload itself raised — which is exactly the case where many threads converge to retry — the throttle was not advanced, so each thread reloaded again immediately on the next call.

This PR moves the update into an `ensure` block so the back-off window applies whether the yield succeeds or fails. The early-return guard remains outside `ensure`, so a no-op (still throttled) call doesn't bump the timer.

## Test plan

- [x] New unit test verifies `@next_reload_time` is updated after a failing yield
- [x] Existing `test_node.rb` still passes
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a bug audit of this codebase.