### PR TITLE
feat: handle bracketed IPv6 addresses in NodeKey

### DIFF
--- a/lib/redis_client/cluster/node_key.rb
+++ b/lib/redis_client/cluster/node_key.rb
@@ -18,11 +18,29 @@ class RedisClient
       end
 
       def split(node_key)
-        pos = node_key&.rindex(DELIMITER, -1)
+        return [node_key, nil] if node_key.nil? || node_key.empty?
+
+        bracketed = split_bracketed(node_key)
+        return bracketed unless bracketed.nil?
+
+        pos = node_key.rindex(DELIMITER, -1)
         return [node_key, nil] if pos.nil?
 
         [node_key[0, pos], node_key[(pos + 1)..]]
       end
+
+      def split_bracketed(node_key)
+        return nil unless node_key.start_with?('[')
+
+        end_bracket = node_key.index(']')
+        return nil if end_bracket.nil?
+
+        host = node_key[1, end_bracket - 1]
+        remainder = node_key[(end_bracket + 1)..]
+        port = remainder.start_with?(DELIMITER) ? remainder[1..] : nil
+        [host, port]
+      end
+      private_class_method :split_bracketed
 
       def build_from_uri(uri)
         return '' if uri.nil?

--- a/test/redis_client/cluster/test_node_key.rb
+++ b/test/redis_client/cluster/test_node_key.rb
@@ -10,6 +10,8 @@ class RedisClient
         [
           { node_key: '127.0.0.1:6379', want: { host: '127.0.0.1', port: '6379' } },
           { node_key: '::1:6379', want: { host: '::1', port: '6379' } },
+          { node_key: '[::1]:6379', want: { host: '::1', port: '6379' } },
+          { node_key: '[2001:db8::1]:6379', want: { host: '2001:db8::1', port: '6379' } },
           { node_key: 'foobar', want: { host: 'foobar', port: nil } },
           { node_key: '', want: { host: '', port: nil } },
           { node_key: nil, want: { host: nil, port: nil } }
@@ -23,6 +25,9 @@ class RedisClient
         [
           { node_key: '127.0.0.1:6379', want: ['127.0.0.1', '6379'] },
           { node_key: '::1:6379', want: ['::1', '6379'] },
+          { node_key: '[::1]:6379', want: ['::1', '6379'] },
+          { node_key: '[2001:db8::1]:6379', want: ['2001:db8::1', '6379'] },
+          { node_key: '[::1]', want: ['::1', nil] },
           { node_key: 'foobar', want: ['foobar', nil] },
           { node_key: '', want: ['', nil] },
           { node_key: nil, want: [nil, nil] }


### PR DESCRIPTION
## Summary

`NodeKey.split` used `rindex(':', -1)` to separate host from port. The bracket-less IPv6 form (`::1:6379`) works correctly because the last `:` is the port delimiter. The standard URL bracketed form (`[::1]:6379`) is mishandled — the host is returned as `'[::1]'` (brackets included), which downstream connection code cannot resolve.

This PR adds explicit handling for the `[host]:port` form: strip the brackets and return the bare host. The legacy path is preserved for all other inputs.

### Scope note

`build_from_host_port` is intentionally left as-is. Changing the produced NodeKey format would affect Hash-key identity in topology bookkeeping, MOVED-response matching, and a number of other invariants. Making `split` tolerant of bracketed *input* is safe; changing produced output is a separate decision.

## Test plan

- [x] Extended `test_split` and `test_hashify` cases for `[::1]:6379`, `[2001:db8::1]:6379`, `[::1]` (no port)
- [x] Existing cases still pass
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a code audit of this codebase.
