### PR TITLE
fix: prune subscription history on unsubscribe in PubSub

### DIFF
--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -64,7 +64,14 @@ class RedisClient
       RECOVERY_BASE_INTERVAL = Float(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_INTERVAL_SEC', 1.0))
       RECOVERY_MAX_INTERVAL = Float(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_MAX_INTERVAL_SEC', 30.0))
       RECOVERY_MAX_ATTEMPTS = Integer(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_MAX_ATTEMPTS', 10))
-      private_constant :BUF_SIZE, :RECOVERY_BASE_INTERVAL, :RECOVERY_MAX_INTERVAL, :RECOVERY_MAX_ATTEMPTS
+      SUBSCRIBE_COMMANDS = %w[subscribe psubscribe ssubscribe].freeze
+      UNSUBSCRIBE_TO_SUBSCRIBE = {
+        'unsubscribe' => 'subscribe',
+        'punsubscribe' => 'psubscribe',
+        'sunsubscribe' => 'ssubscribe'
+      }.freeze
+      private_constant :BUF_SIZE, :RECOVERY_BASE_INTERVAL, :RECOVERY_MAX_INTERVAL, :RECOVERY_MAX_ATTEMPTS,
+                       :SUBSCRIBE_COMMANDS, :UNSUBSCRIBE_TO_SUBSCRIBE
 
       def initialize(router, command_builder)
         @router = router
@@ -77,14 +84,14 @@ class RedisClient
       def call(*args, **kwargs)
         command = @command_builder.generate(args, kwargs)
         _call(command)
-        @commands << command
+        remember(command)
         nil
       end
 
       def call_v(command)
         command = @command_builder.generate(command)
         _call(command)
-        @commands << command
+        remember(command)
         nil
       end
 
@@ -120,6 +127,35 @@ class RedisClient
       end
 
       private
+
+      def remember(command)
+        cmd = command.first.to_s.downcase
+        if SUBSCRIBE_COMMANDS.include?(cmd)
+          @commands << command
+        elsif (subscribe_cmd = UNSUBSCRIBE_TO_SUBSCRIBE[cmd])
+          forget_subscriptions(subscribe_cmd, command[1..])
+        else
+          @commands << command
+        end
+      end
+
+      def forget_subscriptions(subscribe_cmd, channels)
+        if channels.nil? || channels.empty?
+          @commands.reject! { |c| c.first.to_s.casecmp(subscribe_cmd).zero? }
+        else
+          @commands.reject! { |c| prune_entry(c, subscribe_cmd, channels) }
+        end
+      end
+
+      def prune_entry(entry, subscribe_cmd, channels)
+        return false unless entry.first.to_s.casecmp(subscribe_cmd).zero?
+
+        remaining = entry[1..] - channels
+        return true if remaining.empty?
+
+        entry.replace([entry.first, *remaining])
+        false
+      end
 
       def _call(command) # rubocop:disable Metrics/AbcSize
         if command.first.casecmp('subscribe').zero?

--- a/test/redis_client/cluster/test_pub_sub.rb
+++ b/test/redis_client/cluster/test_pub_sub.rb
@@ -6,9 +6,34 @@ require 'redis-cluster-client'
 class RedisClient
   class Cluster
     class TestPubSub < Minitest::Test
-      # Minimal fake router used by start_over. Only renew_cluster_state is exercised
-      # because the rest of the loop body relies on @state_dict and @commands being
-      # empty (the production initial state) so no command dispatch happens.
+      # Stub for the per-node pubsub client returned by `Node#pubsub`.
+      # `PubSub::State#call` invokes `@client.call_v(command)`, so this is
+      # the surface we need.
+      class FakePubSubClient
+        attr_reader :calls
+
+        def initialize
+          @calls = []
+        end
+
+        def call_v(command)
+          @calls << command
+        end
+
+        def close; end
+      end
+
+      class FakeNode
+        def initialize(client)
+          @client = client
+        end
+
+        def pubsub
+          @client
+        end
+      end
+
+      # Fake router used by both routing tests and start_over tests.
       class FakeRouter
         attr_reader :calls
 
@@ -16,6 +41,21 @@ class RedisClient
           @error = error
           @fail_times = fail_times
           @calls = 0
+          @nodes = Hash.new { |h, k| h[k] = FakeNode.new(FakePubSubClient.new) }
+        end
+
+        def find_node_key(command)
+          # Distinct keys per command kind keep call_to_single_state targeting
+          # different nodes. Channel-name-based slot routing is not exercised
+          # because tests inspect @commands, not @state_dict.
+          case command.first.to_s.downcase
+          when 'ssubscribe', 'sunsubscribe' then 'shard:0'
+          else 'primary:0'
+          end
+        end
+
+        def find_node(node_key)
+          @nodes[node_key]
         end
 
         def renew_cluster_state
@@ -27,7 +67,13 @@ class RedisClient
       end
 
       def setup
-        @command_builder = ::RedisClient::CommandBuilder
+        @command_builder = ::RedisClient::Cluster::NoopCommandBuilder
+        @router = FakeRouter.new
+        @pubsub = ::RedisClient::Cluster::PubSub.new(@router, @command_builder)
+      end
+
+      def commands
+        @pubsub.instance_variable_get(:@commands)
       end
 
       def test_start_over_raises_after_exhausting_attempts
@@ -84,6 +130,101 @@ class RedisClient
         assert_equal(base * 2, pubsub.send(:recovery_interval, 2))
         assert_equal(base * 4, pubsub.send(:recovery_interval, 3))
         assert_equal(max, pubsub.send(:recovery_interval, 64))
+      end
+
+      def test_subscribe_then_unsubscribe_prunes_commands
+        @pubsub.call('subscribe', 'a', 'b', 'c')
+        @pubsub.call('unsubscribe', 'b')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[subscribe a c], commands.first)
+      end
+
+      def test_unsubscribe_all_drops_subscribe
+        @pubsub.call('subscribe', 'a', 'b')
+        @pubsub.call('unsubscribe')
+
+        assert_empty(commands)
+      end
+
+      def test_unsubscribe_drops_entry_when_all_channels_match
+        @pubsub.call('subscribe', 'a', 'b')
+        @pubsub.call('unsubscribe', 'a', 'b')
+
+        assert_empty(commands)
+      end
+
+      def test_unsubscribe_unknown_channel_is_noop
+        @pubsub.call('subscribe', 'a')
+        @pubsub.call('unsubscribe', 'z')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[subscribe a], commands.first)
+      end
+
+      def test_psubscribe_independent_from_subscribe
+        @pubsub.call('subscribe', 'a')
+        @pubsub.call('psubscribe', 'p.*')
+        @pubsub.call('unsubscribe', 'a')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[psubscribe p.*], commands.first)
+      end
+
+      def test_punsubscribe_targets_only_psubscribe_entries
+        @pubsub.call('subscribe', 'a')
+        @pubsub.call('psubscribe', 'p.*', 'q.*')
+        @pubsub.call('punsubscribe', 'p.*')
+
+        assert_equal(2, commands.size)
+        assert_equal(%w[subscribe a], commands[0])
+        assert_equal(%w[psubscribe q.*], commands[1])
+      end
+
+      def test_ssubscribe_handled
+        @pubsub.call('ssubscribe', 's1', 's2')
+        @pubsub.call('sunsubscribe', 's1')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[ssubscribe s2], commands.first)
+      end
+
+      def test_sunsubscribe_all_drops_ssubscribe
+        @pubsub.call('ssubscribe', 's1', 's2')
+        @pubsub.call('sunsubscribe')
+
+        assert_empty(commands)
+      end
+
+      def test_unsubscribe_does_not_touch_ssubscribe
+        @pubsub.call('ssubscribe', 's1')
+        @pubsub.call('unsubscribe')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[ssubscribe s1], commands.first)
+      end
+
+      def test_command_name_is_case_insensitive
+        @pubsub.call('SUBSCRIBE', 'a', 'b')
+        @pubsub.call('UnSubScribe', 'a')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[SUBSCRIBE b], commands.first)
+      end
+
+      def test_non_pubsub_commands_are_stored
+        @pubsub.call('ping')
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[ping], commands.first)
+      end
+
+      def test_call_v_uses_remember
+        @pubsub.call_v(%w[subscribe a b])
+        @pubsub.call_v(%w[unsubscribe a])
+
+        assert_equal(1, commands.size)
+        assert_equal(%w[subscribe b], commands.first)
       end
 
       private


### PR DESCRIPTION
## Summary

`Cluster::PubSub` keeps an `@commands` log of every command for replay during `start_over`. Subscribe-family commands (`subscribe`, `psubscribe`, `ssubscribe`) were appended, and unsubscribe-family commands were *also* appended without pruning the matching subscribe entries. Long-lived PubSub clients that rotate channels accumulate unbounded memory, and reconnect replay is O(history) instead of O(active subscriptions).

This PR makes the log represent only the active subscription set: subscribe-family commands append; unsubscribe-family commands prune matching entries by channel and are themselves not stored.

## Test plan

- [x] New unit tests for: subscribe -> unsubscribe (subset), unsubscribe (all), psubscribe / ssubscribe parity, independence of subscribe and psubscribe sets
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a bug audit of this codebase.
