### PR TITLE
fix: bound start_over retries in PubSub recovery

### DIFF
--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -61,7 +61,10 @@ class RedisClient
       end
 
       BUF_SIZE = Integer(ENV.fetch('REDIS_CLIENT_PUBSUB_BUF_SIZE', 1024))
-      private_constant :BUF_SIZE
+      RECOVERY_BASE_INTERVAL = Float(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_INTERVAL_SEC', 1.0))
+      RECOVERY_MAX_INTERVAL = Float(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_MAX_INTERVAL_SEC', 30.0))
+      RECOVERY_MAX_ATTEMPTS = Integer(ENV.fetch('REDIS_CLIENT_PUBSUB_RECOVERY_MAX_ATTEMPTS', 10))
+      private_constant :BUF_SIZE, :RECOVERY_BASE_INTERVAL, :RECOVERY_MAX_INTERVAL, :RECOVERY_MAX_ATTEMPTS
 
       def initialize(router, command_builder)
         @router = router
@@ -179,15 +182,23 @@ class RedisClient
       end
 
       def start_over
+        attempt = 0
         loop do
           @router.renew_cluster_state
           @state_dict.each_value(&:close)
           @state_dict.clear
           @commands.each { |command| _call(command) }
           break
-        rescue ::RedisClient::ConnectionError, ::RedisClient::Cluster::NodeMightBeDown
-          sleep 1.0
+        rescue ::RedisClient::ConnectionError, ::RedisClient::Cluster::NodeMightBeDown => e
+          attempt += 1
+          raise e if attempt >= RECOVERY_MAX_ATTEMPTS
+
+          sleep recovery_interval(attempt)
         end
+      end
+
+      def recovery_interval(attempt)
+        [RECOVERY_BASE_INTERVAL * (2**(attempt - 1)), RECOVERY_MAX_INTERVAL].min
       end
     end
   end

--- a/lib/redis_client/cluster/pub_sub.rb
+++ b/lib/redis_client/cluster/pub_sub.rb
@@ -189,9 +189,9 @@ class RedisClient
           @state_dict.clear
           @commands.each { |command| _call(command) }
           break
-        rescue ::RedisClient::ConnectionError, ::RedisClient::Cluster::NodeMightBeDown => e
+        rescue ::RedisClient::ConnectionError, ::RedisClient::Cluster::NodeMightBeDown
           attempt += 1
-          raise e if attempt >= RECOVERY_MAX_ATTEMPTS
+          raise if attempt >= RECOVERY_MAX_ATTEMPTS
 
           sleep recovery_interval(attempt)
         end

--- a/test/redis_client/cluster/test_pub_sub.rb
+++ b/test/redis_client/cluster/test_pub_sub.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'redis-cluster-client'
+
+class RedisClient
+  class Cluster
+    class TestPubSub < Minitest::Test
+      # Minimal fake router used by start_over. Only renew_cluster_state is exercised
+      # because the rest of the loop body relies on @state_dict and @commands being
+      # empty (the production initial state) so no command dispatch happens.
+      class FakeRouter
+        attr_reader :calls
+
+        def initialize(error: nil, fail_times: 0)
+          @error = error
+          @fail_times = fail_times
+          @calls = 0
+        end
+
+        def renew_cluster_state
+          @calls += 1
+          raise @error if @error && @calls <= @fail_times
+
+          nil
+        end
+      end
+
+      def setup
+        @command_builder = ::RedisClient::CommandBuilder
+      end
+
+      def test_start_over_raises_after_exhausting_attempts
+        router = FakeRouter.new(error: ::RedisClient::ConnectionError.new('boom'), fail_times: Float::INFINITY)
+        pubsub = ::RedisClient::Cluster::PubSub.new(router, @command_builder)
+        skip_sleep(pubsub)
+
+        max_attempts = ::RedisClient::Cluster::PubSub.const_get(:RECOVERY_MAX_ATTEMPTS, false)
+
+        err = assert_raises(::RedisClient::ConnectionError) { pubsub.send(:start_over) }
+        assert_equal('boom', err.message)
+        assert_equal(max_attempts, router.calls)
+      end
+
+      def test_start_over_raises_for_node_might_be_down_after_exhausting_attempts
+        router = FakeRouter.new(error: ::RedisClient::Cluster::NodeMightBeDown.new, fail_times: Float::INFINITY)
+        pubsub = ::RedisClient::Cluster::PubSub.new(router, @command_builder)
+        skip_sleep(pubsub)
+
+        max_attempts = ::RedisClient::Cluster::PubSub.const_get(:RECOVERY_MAX_ATTEMPTS, false)
+
+        assert_raises(::RedisClient::Cluster::NodeMightBeDown) { pubsub.send(:start_over) }
+        assert_equal(max_attempts, router.calls)
+      end
+
+      def test_start_over_succeeds_after_transient_failure
+        max_attempts = ::RedisClient::Cluster::PubSub.const_get(:RECOVERY_MAX_ATTEMPTS, false)
+        fail_times = max_attempts - 1
+        router = FakeRouter.new(error: ::RedisClient::ConnectionError.new('transient'), fail_times: fail_times)
+        pubsub = ::RedisClient::Cluster::PubSub.new(router, @command_builder)
+        skip_sleep(pubsub)
+
+        assert_nil(pubsub.send(:start_over))
+        assert_equal(fail_times + 1, router.calls)
+      end
+
+      def test_start_over_succeeds_on_first_try
+        router = FakeRouter.new
+        pubsub = ::RedisClient::Cluster::PubSub.new(router, @command_builder)
+        skip_sleep(pubsub)
+
+        assert_nil(pubsub.send(:start_over))
+        assert_equal(1, router.calls)
+      end
+
+      def test_recovery_interval_uses_exponential_backoff_capped_by_max
+        router = FakeRouter.new
+        pubsub = ::RedisClient::Cluster::PubSub.new(router, @command_builder)
+
+        base = ::RedisClient::Cluster::PubSub.const_get(:RECOVERY_BASE_INTERVAL, false)
+        max = ::RedisClient::Cluster::PubSub.const_get(:RECOVERY_MAX_INTERVAL, false)
+
+        assert_equal(base, pubsub.send(:recovery_interval, 1))
+        assert_equal(base * 2, pubsub.send(:recovery_interval, 2))
+        assert_equal(base * 4, pubsub.send(:recovery_interval, 3))
+        assert_equal(max, pubsub.send(:recovery_interval, 64))
+      end
+
+      private
+
+      def skip_sleep(pubsub)
+        # Avoid real sleeping in tests. Backoff math is verified by
+        # test_recovery_interval_uses_exponential_backoff_capped_by_max.
+        pubsub.define_singleton_method(:sleep) { |_seconds| nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`PubSub#start_over` previously looped indefinitely (`sleep 1.0` on each `ConnectionError` / `NodeMightBeDown`) when the cluster could not recover — e.g., DNS failure, network partition, all nodes lost. The user's `next_event` thread had no way out except killing the thread or closing the pubsub from another thread.

This PR adds bounded attempts with exponential backoff (base 1s, cap 30s, default 10 attempts). Tunable via:

- `REDIS_CLIENT_PUBSUB_RECOVERY_INTERVAL_SEC` (default `1.0`)
- `REDIS_CLIENT_PUBSUB_RECOVERY_MAX_INTERVAL_SEC` (default `30.0`)
- `REDIS_CLIENT_PUBSUB_RECOVERY_MAX_ATTEMPTS` (default `10`)

After exhaustion, the underlying error is re-raised so the caller can decide how to handle it.

## Behavior change

Previously: blocks forever on permanent cluster failure.
Now: raises `ConnectionError` / `NodeMightBeDown` after the configured attempts (~150s with defaults).

Open to discussion on the default values.

## Test plan

- [x] New unit tests for both transient (recovers) and persistent (raises) paths
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a bug audit of this codebase.