### PR TITLE
fix: redact credentials in ClusterConfig#inspect

### DIFF
--- a/lib/redis_client/cluster_config.rb
+++ b/lib/redis_client/cluster_config.rb
@@ -32,6 +32,12 @@ class RedisClient
 
     InvalidClientConfigError = Class.new(::RedisClient::Cluster::Error)
 
+    SENSITIVE_INSPECT_KEYS = %i[username password].freeze
+    INSPECT_REDACTED_KEYS = %i[command_builder].freeze
+    INSPECT_PLACEHOLDER = '[FILTERED]'
+
+    private_constant :SENSITIVE_INSPECT_KEYS, :INSPECT_REDACTED_KEYS, :INSPECT_PLACEHOLDER
+
     attr_reader :command_builder, :client_config, :replica_affinity, :slow_command_timeout,
                 :connect_with_original_config, :startup_nodes, :max_startup_sample, :id
 
@@ -65,7 +71,7 @@ class RedisClient
     end
 
     def inspect
-      "#<#{self.class.name} #{startup_nodes.values.map { |v| v.reject { |k| k == :command_builder } }}>"
+      "#<#{self.class.name} #{startup_nodes.values.map { |v| redact_for_inspect(v) }}>"
     end
 
     def connect_timeout
@@ -116,6 +122,14 @@ class RedisClient
     end
 
     private
+
+    def redact_for_inspect(node_config)
+      node_config.each_with_object({}) do |(key, value), redacted|
+        next if INSPECT_REDACTED_KEYS.include?(key)
+
+        redacted[key] = SENSITIVE_INSPECT_KEYS.include?(key) ? INSPECT_PLACEHOLDER : value
+      end
+    end
 
     def merge_concurrency_option(option)
       opts = {}

--- a/test/redis_client/test_cluster_config.rb
+++ b/test/redis_client/test_cluster_config.rb
@@ -12,6 +12,24 @@ class RedisClient
       assert_equal(want, got)
     end
 
+    def test_inspect_redacts_credentials
+      url_config = ::RedisClient::ClusterConfig.new(nodes: ['redis://alice:s3cret@127.0.0.1:6379'])
+      url_inspect = url_config.inspect
+      refute_includes(url_inspect, 'alice', 'username from URL must not appear in inspect')
+      refute_includes(url_inspect, 's3cret', 'password from URL must not appear in inspect')
+      assert_includes(url_inspect, '[FILTERED]', 'inspect must contain redaction placeholder')
+      assert_equal(2, url_inspect.scan('[FILTERED]').size, 'both username and password must be redacted')
+
+      hash_config = ::RedisClient::ClusterConfig.new(
+        nodes: [{ host: 'h', port: 6379, username: 'u', password: 'p' }]
+      )
+      hash_inspect = hash_config.inspect
+      refute_match(/(?<![A-Za-z])u(?![A-Za-z])/, hash_inspect, 'username from hash must not appear in inspect')
+      refute_match(/(?<![A-Za-z])p(?![A-Za-z])/, hash_inspect, 'password from hash must not appear in inspect')
+      assert_includes(hash_inspect, '[FILTERED]', 'inspect must contain redaction placeholder')
+      assert_equal(2, hash_inspect.scan('[FILTERED]').size, 'both username and password must be redacted')
+    end
+
     def test_new_pool
       assert_instance_of(
         ::RedisClient::Cluster,


### PR DESCRIPTION
## Summary

`RedisClient::ClusterConfig#inspect` previously rendered the full startup_nodes hashes — including raw `:username` and `:password` values — into its inspect string. This caused credentials to leak into:

- Application logs (via `Logger#debug config`)
- Exception backtraces that include config in their message
- IRB / Pry sessions
- APM error reports

The upstream `redis-client` gem wraps the password in a Proc to prevent this exact leak; this gem stored raw values and exposed them.

This PR redacts `:username` and `:password` to `'[FILTERED]'` before building the inspect string.

## Test plan

- [x] New `test_inspect_redacts_credentials` covering both URL and hash forms
- [x] Existing `test_inspect` still passes
- [x] `bundle exec rubocop` clean

---

This PR was authored by [Claude Code](https://www.anthropic.com/claude-code) (model: Opus 4.7) following a security audit of this codebase. Please review the diff carefully — feedback welcome.
