### PR TITLE
chore: add valkey client to bench

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem 'rubocop-minitest', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rake', require: false
 gem 'stackprof', platform: :mri
+gem 'valkey-rb'
 gem 'vernier', platform: :mri if RUBY_ENGINE == 'ruby' && Integer(RUBY_VERSION.split('.').first) > 2

--- a/compose.latency.yaml
+++ b/compose.latency.yaml
@@ -37,7 +37,7 @@ services:
       bash -c "apt-get update > /dev/null
       && apt-get install --no-install-recommends --no-install-suggests -y iproute2 iputils-ping > /dev/null
       && rm -rf /var/lib/apt/lists/*
-      && (tc qdisc add dev eth0 root netem delay ${DELAY_TIME:-1ms} || echo skipped)
+      && (tc qdisc add dev eth0 root netem delay ${DELAY_TIME:-0ms} || echo skipped)
       && redis-server
       --maxmemory            64mb
       --maxmemory-policy     allkeys-lru
@@ -111,7 +111,7 @@ services:
       - -l
       - warn
     ports:
-      - "3000:10000"
+      - "8080:10000"
       - "7000:10001"
     volumes:
       - ./test/proxy/envoy.yaml:/etc/envoy/envoy.yaml

--- a/test/ips_pipeline.rb
+++ b/test/ips_pipeline.rb
@@ -3,6 +3,8 @@
 require 'benchmark/ips'
 require 'redis_cluster_client'
 require 'testing_constants'
+require 'async/redis/cluster_client'
+require 'valkey'
 
 module IpsPipeline
   module_function
@@ -10,20 +12,18 @@ module IpsPipeline
   ATTEMPTS = 100
 
   def run
-    on_demand = make_client(:on_demand)
-    pooled = make_client(:pooled)
-    none = make_client(:none)
-    envoy = make_client_for_envoy
-    cluster_proxy = make_client_for_cluster_proxy
-    prepare(on_demand, pooled, none, envoy, cluster_proxy)
     print_letter('pipelined')
+    cli = make_client(:none)
+    prepare(cli)
     bench(
-      ondemand: on_demand,
-      pooled: pooled,
-      none: none,
-      envoy: envoy,
-      cproxy: cluster_proxy
+      none: cli,
+      pooled: make_client(:pooled),
+      ondemand: make_client(:on_demand),
+      envoy: make_client_for_envoy,
+      cproxy: make_client_for_cluster_proxy
     )
+    # async_bench(make_async_client)
+    valkey_bench(make_valkey_client)
   end
 
   def make_client(model)
@@ -49,6 +49,20 @@ module IpsPipeline
     ).new_client
   end
 
+  def make_async_client
+    endpoints = TEST_NODE_URIS.map { |e| ::Async::Redis::Endpoint.parse(e) }
+    ::Async::Redis::ClusterClient.new(endpoints)
+  end
+
+  def make_valkey_client
+    ::Valkey.new(
+      nodes: [{ host: TEST_REDIS_HOST, port: TEST_REDIS_PORT }],
+      timeout: TEST_TIMEOUT_SEC,
+      cluster_mode: true,
+      protocol: 3
+    )
+  end
+
   def print_letter(title)
     print "################################################################################\n"
     print "# #{title}\n"
@@ -56,12 +70,10 @@ module IpsPipeline
     print "\n"
   end
 
-  def prepare(*clients)
-    clients.each do |client|
-      client.pipelined do |pi|
-        ATTEMPTS.times do |i|
-          pi.call('set', "key#{i}", "val#{i}")
-        end
+  def prepare(client)
+    client.pipelined do |pi|
+      ATTEMPTS.times do |i|
+        pi.call('set', "key#{i}", "val#{i}")
       end
     end
   end
@@ -77,6 +89,43 @@ module IpsPipeline
             ATTEMPTS.times do |i|
               pi.call('get', "key#{i}")
             end
+          end
+        end
+      end
+
+      x.compare!
+    end
+  end
+
+  def async_bench(client)
+    Async do
+      Benchmark.ips do |x|
+        x.time = 5
+        x.warmup = 1
+
+        x.report('pipelined: async') do
+          # FIXME: supported or not?
+          client.pipeline do |pi|
+            ATTEMPTS.times do |i|
+              pi.call('get', "key#{i}")
+            end
+          end
+        end
+
+        x.compare!
+      end
+    end
+  end
+
+  def valkey_bench(client)
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+
+      x.report('pipelined: valkey') do
+        client.pipelined do |pi|
+          ATTEMPTS.times do |i|
+            pi.get("key#{i}")
           end
         end
       end

--- a/test/ips_single.rb
+++ b/test/ips_single.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require 'async/redis/cluster_client'
 require 'benchmark/ips'
 require 'redis_cluster_client'
 require 'testing_constants'
+require 'async/redis/cluster_client'
+require 'valkey'
 
 module IpsSingle
   module_function
@@ -11,17 +12,16 @@ module IpsSingle
   ATTEMPTS = 10
 
   def run
-    cli = make_client
-    envoy = make_client_for_envoy
-    cluster_proxy = make_client_for_cluster_proxy
-    prepare(cli, envoy, cluster_proxy)
     print_letter('single')
+    cli = make_client
+    prepare(cli)
     bench(
       cli: cli,
-      envoy: envoy,
-      cproxy: cluster_proxy
+      envoy: make_client_for_envoy,
+      cproxy: make_client_for_cluster_proxy
     )
     async_bench(make_async_client)
+    valkey_bench(make_valkey_client)
   end
 
   def make_client
@@ -51,6 +51,15 @@ module IpsSingle
     ::Async::Redis::ClusterClient.new(endpoints)
   end
 
+  def make_valkey_client
+    ::Valkey.new(
+      nodes: [{ host: TEST_REDIS_HOST, port: TEST_REDIS_PORT }],
+      timeout: TEST_TIMEOUT_SEC,
+      cluster_mode: true,
+      protocol: 3
+    )
+  end
+
   def print_letter(title)
     print "################################################################################\n"
     print "# #{title}\n"
@@ -58,11 +67,9 @@ module IpsSingle
     print "\n"
   end
 
-  def prepare(*clients)
-    clients.each do |client|
-      ATTEMPTS.times do |i|
-        client.call('set', "key#{i}", "val#{i}")
-      end
+  def prepare(client)
+    ATTEMPTS.times do |i|
+      client.call('set', "key#{i}", "val#{i}")
     end
   end
 
@@ -84,18 +91,33 @@ module IpsSingle
   end
 
   def async_bench(cluster)
-    Benchmark.ips do |x|
-      x.time = 5
-      x.warmup = 1
+    Async do
+      Benchmark.ips do |x|
+        x.time = 5
+        x.warmup = 1
 
-      x.report('single: async') do
-        Async do
+        x.report('single: async') do
           ATTEMPTS.times do |i|
             key = "key#{i}"
             slot = cluster.slot_for(key)
             client = cluster.client_for(slot)
             client.get(key)
           end
+        end
+
+        x.compare!
+      end
+    end
+  end
+
+  def valkey_bench(client)
+    Benchmark.ips do |x|
+      x.time = 5
+      x.warmup = 1
+
+      x.report('single: valkey') do
+        ATTEMPTS.times do |i|
+          client.get("key#{i}")
         end
       end
 


### PR DESCRIPTION
[valkey-rb](https://github.com/valkey-io/valkey-glide-ruby)'s pipeline is much faster than we are. Their async runtime is awesome.

```
AMD EPYC 7763 64-Core Processor * 4
```

```
ruby 4.0.3 (2026-04-21 revision 85ddef263a) +PRISM [x86_64-linux]
```

`none`, `pooled`, `ondemand` are us. `cproxy` is an official [proxy](https://github.com/RedisLabs/redis-cluster-proxy). (not production ready)

```
   pipelined: valkey     1.300k (± 2.2%) i/s  (768.95 μs/i) -      6.630k in   5.100466s
     pipelined: none    753.190 (± 5.8%) i/s    (1.33 ms/i) -      3.800k in   5.068582s
   pipelined: pooled    730.257 (± 1.0%) i/s    (1.37 ms/i) -      3.723k in   5.098651s
    pipelined: envoy    716.418 (± 6.8%) i/s    (1.40 ms/i) -      3.621k in   5.086820s
 pipelined: ondemand    658.976 (± 6.7%) i/s    (1.52 ms/i) -      3.283k in   5.014373s
   pipelined: cproxy    435.246 (± 0.9%) i/s    (2.30 ms/i) -      2.193k in   5.039049s
```

`cli` is us. `async` is [socketry/async-redis](https://github.com/socketry/async-redis).

```
         single: cli     1.073k (± 5.2%) i/s  (931.84 μs/i) -      5.459k in   5.100874s
       single: async    968.634 (± 8.5%) i/s    (1.03 ms/i) -      4.823k in   5.020212s
      single: valkey    733.874 (± 6.1%) i/s    (1.36 ms/i) -      3.724k in   5.094453s
      single: cproxy    459.381 (± 4.6%) i/s    (2.18 ms/i) -      2.295k in   5.007892s
       single: envoy    333.235 (± 4.8%) i/s    (3.00 ms/i) -      1.666k in   5.012606s
```

Our single command:
<img width="3439" height="656" alt="single" src="https://github.com/user-attachments/assets/fc9bf421-1ea2-49f1-8b5e-709b8a2bf712" />

Our Pipeline command:
<img width="3439" height="704" alt="pipeline" src="https://github.com/user-attachments/assets/bb2ad5e1-f371-44d8-9731-f6ba3ef7410e" />

[vernier.zip](https://github.com/user-attachments/files/27317055/vernier.zip)
