### PR TITLE
fix: pin a node during a pipeline or scan even if random-scale reading

### DIFF
--- a/lib/redis_client/cluster.rb
+++ b/lib/redis_client/cluster.rb
@@ -95,13 +95,12 @@ class RedisClient
     end
 
     def pipelined(exception: true)
-      seed = @config.use_replica? && @config.replica_affinity == :random ? nil : Random.new_seed
       pipeline = ::RedisClient::Cluster::Pipeline.new(
         router,
         @command_builder,
         @concurrent_worker,
         exception: exception,
-        seed: seed
+        seed: Random.new_seed
       )
 
       yield pipeline

--- a/lib/redis_client/cluster/node/base_topology.rb
+++ b/lib/redis_client/cluster/node/base_topology.rb
@@ -25,8 +25,7 @@ class RedisClient
         end
 
         def any_primary_node_key(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @primary_node_keys.sample(random: random)
+          @primary_node_keys.sample(random: make_random(seed))
         end
 
         def process_topology_update!(replications, options) # rubocop:disable Metrics/AbcSize
@@ -58,6 +57,11 @@ class RedisClient
             client = @pool.nil? ? config.new_client : config.new_pool(**@pool)
             @clients[node_key] = client
           end
+        end
+
+        def make_random(seed)
+          # OPTIMIZE: Figure out the most elegant way to pin a node during a pipeline or scan.
+          seed.nil? ? Random : Random.new(seed)
         end
       end
     end

--- a/lib/redis_client/cluster/node/latency_replica.rb
+++ b/lib/redis_client/cluster/node/latency_replica.rb
@@ -20,8 +20,7 @@ class RedisClient
         end
 
         def any_replica_node_key(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @existed_replicas.sample(random: random)&.first || any_primary_node_key(seed: seed)
+          @existed_replicas.sample(random: make_random(seed))&.first || any_primary_node_key(seed: seed)
         end
 
         def process_topology_update!(replications, options)

--- a/lib/redis_client/cluster/node/primary_only.rb
+++ b/lib/redis_client/cluster/node/primary_only.rb
@@ -18,8 +18,7 @@ class RedisClient
         end
 
         def any_primary_node_key(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @primary_node_keys.sample(random: random)
+          @primary_node_keys.sample(random: make_random(seed))
         end
 
         alias any_replica_node_key any_primary_node_key

--- a/lib/redis_client/cluster/node/random_replica.rb
+++ b/lib/redis_client/cluster/node/random_replica.rb
@@ -12,7 +12,7 @@ class RedisClient
         end
 
         def clients_for_scanning(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
+          random = make_random(seed)
           keys = @replications.map do |primary_node_key, replica_node_keys|
             replica_node_keys.empty? ? primary_node_key : replica_node_keys.sample(random: random)
           end
@@ -21,13 +21,13 @@ class RedisClient
         end
 
         def find_node_key_of_replica(primary_node_key, seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @replications.fetch(primary_node_key, EMPTY_ARRAY).sample(random: random) || primary_node_key
+          replica_node_keys = @replications.fetch(primary_node_key, EMPTY_ARRAY)
+          replica_node_key = replica_node_keys.size <= 1 ? replica_node_keys.first : replica_node_keys.sample(random: make_random(seed))
+          replica_node_key || primary_node_key
         end
 
         def any_replica_node_key(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @replica_node_keys.sample(random: random) || any_primary_node_key(seed: seed)
+          @replica_node_keys.sample(random: make_random(seed)) || any_primary_node_key(seed: seed)
         end
       end
     end

--- a/lib/redis_client/cluster/node/random_replica_or_primary.rb
+++ b/lib/redis_client/cluster/node/random_replica_or_primary.rb
@@ -12,7 +12,7 @@ class RedisClient
         end
 
         def clients_for_scanning(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
+          random = make_random(seed)
           keys = @replications.map do |primary_node_key, replica_node_keys|
             decide_use_primary?(random, replica_node_keys.size) ? primary_node_key : replica_node_keys.sample(random: random)
           end
@@ -21,7 +21,7 @@ class RedisClient
         end
 
         def find_node_key_of_replica(primary_node_key, seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
+          random = make_random(seed)
 
           replica_node_keys = @replications.fetch(primary_node_key, EMPTY_ARRAY)
           if decide_use_primary?(random, replica_node_keys.size)
@@ -32,8 +32,7 @@ class RedisClient
         end
 
         def any_replica_node_key(seed: nil)
-          random = seed.nil? ? Random : Random.new(seed)
-          @replica_node_keys.sample(random: random) || any_primary_node_key(seed: seed)
+          @replica_node_keys.sample(random: make_random(seed)) || any_primary_node_key(seed: seed)
         end
 
         private

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -467,8 +467,13 @@ class RedisClient
 
         return assign_node_and_send_command(method, command, args, &block) if command.size <= keys_step + 1 || ::RedisClient::Cluster::KeySlotConverter.hash_tag_included?(command[1])
 
-        seed = @config.use_replica? && @config.replica_affinity == :random ? nil : Random.new_seed
-        pipeline = ::RedisClient::Cluster::Pipeline.new(self, @command_builder, @concurrent_worker, exception: true, seed: seed)
+        pipeline = ::RedisClient::Cluster::Pipeline.new(
+          self,
+          @command_builder,
+          @concurrent_worker,
+          exception: true,
+          seed: Random.new_seed
+        )
 
         single_command = Array.new(keys_step + 1)
         single_command[0] = single_key_cmd


### PR DESCRIPTION
If a primary node has many replica nodes, I think it would be effective to send batch commands to a pinned node in each shard during a pipeline. The more nodes to access, the more time it takes to process because Ruby tends to have concurrency overhead. The only downside of our implementation is the increasing memory consumption of the random object.