### PR TITLE
fix: prefer endpoint over ip in CLUSTER SHARDS topology parsing

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -412,19 +412,38 @@ class RedisClient
           primary_id = nodes.find { |n| n.fetch('role') == 'master' }.fetch('id')
 
           nodes.each do |node|
-            ip = node.fetch('ip')
-            next if node.fetch('health') != 'online' || ip.nil? || ip.empty? || ip == '?'
+            host = pick_shard_host(node)
+            next if node.fetch('health') != 'online' || host.nil? || host.empty? || host == '?'
 
             role = node.fetch('role')
             acc << ::RedisClient::Cluster::Node::Info.new(
               id: node.fetch('id'),
-              node_key: NodeKey.build_from_host_port(ip, node['port'] || node['tls-port']),
+              node_key: NodeKey.build_from_host_port(host, node['port'] || node['tls-port']),
               role: role == 'master' ? role : 'slave',
               primary_id: role == 'master' ? EMPTY_STRING : primary_id,
               slots: role == 'master' ? shard.fetch('slots').each_slice(2).to_a.freeze : EMPTY_ARRAY
             )
           end
         end
+      end
+
+      # Pick the host for a CLUSTER SHARDS node entry.
+      #
+      # `endpoint` is the server-selected preferred endpoint (driven by the
+      # `cluster-preferred-endpoint-type` config), so prefer it when present and
+      # usable. Some managed services (e.g. AWS ElastiCache Serverless) report
+      # `127.0.0.1` in `ip` while exposing the reachable address only via
+      # `endpoint` / `hostname`; falling through to `ip` in that case would build
+      # an unreachable topology. This mirrors the precedence `parse_node_key`
+      # uses for CLUSTER NODES output (see #207).
+      def pick_shard_host(node)
+        endpoint = node['endpoint']
+        return endpoint if endpoint && !endpoint.empty? && endpoint != '?'
+
+        hostname = node['hostname']
+        return hostname if hostname && !hostname.empty?
+
+        node['ip']
       end
 
       # As redirection node_key is dependent on `cluster-preferred-endpoint-type` config,

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -509,6 +509,89 @@ class RedisClient
         assert_equal(want.sort_by { |e| e.fetch(:id) }, got.sort_by(&:id).map(&:to_h))
       end
 
+      def test_parse_cluster_shards_reply_prefers_endpoint_over_ip
+        # AWS ElastiCache Serverless reports `127.0.0.1` in `ip` and the real
+        # FQDN in `endpoint`/`hostname`. The parser must build node_keys from
+        # `endpoint` so the resulting topology is reachable.
+        reply = [
+          {
+            'slots' => [0, 16_383],
+            'nodes' => [
+              {
+                'id' => '378a36b26f92565b8839570562532b0800000000',
+                'tls-port' => 6379,
+                'ip' => '127.0.0.1',
+                'endpoint' => 'cache.example.com',
+                'hostname' => 'cache.example.com',
+                'role' => 'master',
+                'replication-offset' => 0,
+                'health' => 'online'
+              },
+              {
+                'id' => '8bbdfb0ec88b53eabcecf25ccb2e16b000000000',
+                'tls-port' => 6380,
+                'ip' => '127.0.0.1',
+                'endpoint' => 'cache.example.com',
+                'hostname' => 'cache.example.com',
+                'role' => 'replica',
+                'replication-offset' => 0,
+                'health' => 'online'
+              }
+            ]
+          }
+        ]
+
+        got = @test_node.send(:parse_cluster_shards_reply, reply)
+
+        assert_equal(%w[cache.example.com:6379 cache.example.com:6380], got.map(&:node_key).sort)
+      end
+
+      def test_parse_cluster_shards_reply_falls_back_to_hostname_when_endpoint_unknown
+        reply = [
+          {
+            'slots' => [0, 16_383],
+            'nodes' => [
+              {
+                'id' => '378a36b26f92565b8839570562532b0800000000',
+                'port' => 6379,
+                'ip' => '10.0.0.1',
+                'endpoint' => '?',
+                'hostname' => 'node.example.com',
+                'role' => 'master',
+                'replication-offset' => 0,
+                'health' => 'online'
+              }
+            ]
+          }
+        ]
+
+        got = @test_node.send(:parse_cluster_shards_reply, reply)
+
+        assert_equal(['node.example.com:6379'], got.map(&:node_key))
+      end
+
+      def test_parse_cluster_shards_reply_falls_back_to_ip_when_no_endpoint_or_hostname
+        reply = [
+          {
+            'slots' => [0, 16_383],
+            'nodes' => [
+              {
+                'id' => '378a36b26f92565b8839570562532b0800000000',
+                'port' => 6379,
+                'ip' => '10.0.0.1',
+                'role' => 'master',
+                'replication-offset' => 0,
+                'health' => 'online'
+              }
+            ]
+          }
+        ]
+
+        got = @test_node.send(:parse_cluster_shards_reply, reply)
+
+        assert_equal(['10.0.0.1:6379'], got.map(&:node_key))
+      end
+
       def test_inspect
         assert_match(/^#<RedisClient::Cluster::Node [0-9., :]*>$/, @test_node.inspect)
       end


### PR DESCRIPTION
Fixes #515.

## Problem

Since v0.16.0 (#479) switched topology discovery to `CLUSTER SHARDS`,
`parse_cluster_shards_reply` only consumes the `ip` field and ignores
`endpoint` / `hostname`. Some managed services (notably AWS ElastiCache
Serverless) report `127.0.0.1` in `ip` while exposing the real, reachable
address only via `endpoint` / `hostname`, so the resulting topology is
unreachable and the next operation that walks all nodes (e.g. `SCAN` /
`Rails.cache.delete_matched`) fails with `Connection refused`.

See #515 for the actual `CLUSTER SHARDS` reply captured from ElastiCache
Serverless.

## Fix

Pick the host using `endpoint` → `hostname` → `ip`, mirroring the
precedence `parse_node_key` already uses for `CLUSTER NODES` (added in
#207).

- `endpoint` is the server-selected preferred endpoint per
  `cluster-preferred-endpoint-type`, so it is the authoritative choice
  when present and not `?`.
- When `endpoint` is `?` or absent, fall back to `hostname`.
- When neither is available, fall back to `ip` (existing behavior).