### PR TITLE
Add support for MULTI/EXEC on pipelines

### DIFF
--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -176,7 +176,7 @@ class RedisClient
         @multi_exec_indices.add(@size)
 
         node_key = transaction.node_key
-        inner_lo = (@pipelines || {})[node_key]&.size || 0
+        inner_lo = (@pipelines || {})[node_key]&._size || 0
 
         transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
           append_pipeline_noreply(node_key).call_once_v(command, &block)

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -127,6 +127,7 @@ class RedisClient
         @seed = seed
         @pipelines = nil
         @size = 0
+        @multi_exec_metadata = {}
       end
 
       def call(*args, **kwargs, &block)
@@ -171,6 +172,11 @@ class RedisClient
         slots = transaction.pipeline._commands.map { |command| @router.find_slot(command) }.compact.uniq
         raise ::RedisClient::Cluster::Transaction::ConsistencyError.new('unable to determine slot').with_config(@router.config) if transaction.node_key.nil? || slots.size != 1
 
+        @multi_exec_metadata[@size] = {
+          outer: @size,
+          node_key: transaction.node_key
+        }
+
         transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
           append_pipeline_noreply(transaction.node_key).call_once_v(command, &block)
         end
@@ -211,7 +217,17 @@ class RedisClient
             errors[node_key] = v
           else
             all_replies ||= Array.new(@size)
-            @pipelines[node_key].outer_indices.each_with_index { |outer, inner| all_replies[outer] = v[inner] }
+            @pipelines[node_key].outer_indices.each_with_index do |outer, inner|
+              if @multi_exec_metadata.key?(outer) && v[inner].is_a?(Array)
+                v[inner].each do |result|
+                  if result.is_a?(::RedisClient::CommandError)
+                    errors ||= {}
+                    errors[node_key] = result
+                  end
+                end
+              end
+              all_replies[outer] = v[inner]
+            end
           end
         end
 

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -193,7 +193,7 @@ class RedisClient
         @size.zero?
       end
 
-      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity,Metrics/MethodLength
         return if @pipelines.nil? || @pipelines.empty?
 
         work_group = @concurrent_worker.new_group(size: @pipelines.size)

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -165,6 +165,17 @@ class RedisClient
         append_pipeline(node_key).blocking_call_v(timeout, command, &block)
       end
 
+      def multi
+        transaction = ::RedisClient::Cluster::Transaction.new(@router, @command_builder)
+        yield transaction
+        raise ConsistencyError.new('unable to determine slot').with_config(@router.config) if transaction.node_key.nil?
+
+        transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
+          append_pipeline_noreply(transaction.node_key).call_once_v(command, &block)
+        end
+        append_pipeline(transaction.node_key).call_once('EXEC')
+      end
+
       def empty?
         @size.zero?
       end
@@ -234,6 +245,16 @@ class RedisClient
         pi.add_outer_index(@size)
         @size += 1
         pi
+      end
+
+      # don't increment the size so that the next command
+      # will override the reply (for pipelined multis to
+      # remove all the "OK" and "QUEUED responses")
+      def append_pipeline_noreply(node_key)
+        @pipelines ||= {}
+        @pipelines[node_key] ||= ::RedisClient::Cluster::Pipeline::Extended.new(::RedisClient::Cluster::NoopCommandBuilder)
+        @pipelines[node_key].add_outer_index(@size)
+        @pipelines[node_key]
       end
 
       def do_pipelining(client, pipeline)

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'set'
 require 'redis_client'
 require 'redis_client/cluster/errors'
 require 'redis_client/cluster/noop_command_builder'
@@ -241,11 +242,23 @@ class RedisClient
         raise ::RedisClient::Cluster::ErrorCollection.with_errors(errors).with_config(@router.config) unless errors.nil?
 
         required_redirections&.each do |node_key, v|
-          raise v.first_exception if v.first_exception
-
           all_replies ||= Array.new(@size)
           pipeline = @pipelines[node_key]
-          v.indices.each { |i| v.replies[i] = handle_redirection(node_key, v.replies[i], pipeline, i) }
+          redirected_segments = Set.new
+          v.indices.each do |i|
+            segment = find_multi_exec_segment(node_key, i)
+            if segment
+              key = [node_key, segment.begin, segment.end]
+              next if redirected_segments.include?(key)
+
+              redirected_segments.add(key)
+              v.replies[segment.end] = handle_redirection(node_key, v.replies[i], pipeline, i)
+            else
+              v.replies[i] = handle_redirection(node_key, v.replies[i], pipeline, i)
+            end
+          end
+          raise v.first_exception if v.first_exception && redirected_segments.empty?
+
           pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
         end
 
@@ -312,10 +325,25 @@ class RedisClient
         end
       end
 
+      def find_multi_exec_segment(node_key, inner_index)
+        (@multi_exec_segments[node_key] || []).find { |segment| segment.include?(inner_index) }
+      end
+
       def try_redirection(node_key, node, pipeline, inner_index)
-        redirect_command(node, pipeline, inner_index) unless (@multi_exec_segments[node_key] || []).any? { |segment| segment.include?(inner_index) }
+        segment = find_multi_exec_segment(node_key, inner_index)
+        if segment
+          redirect_multi_exec_segment(node, pipeline, segment)
+        else
+          redirect_command(node, pipeline, inner_index)
+        end
       rescue StandardError => e
         @exception ? raise : e
+      end
+
+      def redirect_multi_exec_segment(node, pipeline, segment)
+        segment.map do |inner_index|
+          redirect_command(node, pipeline, inner_index)
+        end.last
       end
 
       def redirect_command(node, pipeline, inner_index)

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -127,7 +127,7 @@ class RedisClient
         @seed = seed
         @pipelines = nil
         @size = 0
-        @multi_exec_metadata = {}
+        @multi_exec_indices = Set.new
       end
 
       def call(*args, **kwargs, &block)
@@ -172,10 +172,7 @@ class RedisClient
         slots = transaction.pipeline._commands.map { |command| @router.find_slot(command) }.compact.uniq
         raise ::RedisClient::Cluster::Transaction::ConsistencyError.new('unable to determine slot').with_config(@router.config) if transaction.node_key.nil? || slots.size != 1
 
-        @multi_exec_metadata[@size] = {
-          outer: @size,
-          node_key: transaction.node_key
-        }
+        @multi_exec_indices.add(@size)
 
         transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
           append_pipeline_noreply(transaction.node_key).call_once_v(command, &block)
@@ -218,7 +215,7 @@ class RedisClient
           else
             all_replies ||= Array.new(@size)
             @pipelines[node_key].outer_indices.each_with_index do |outer, inner|
-              if @multi_exec_metadata.key?(outer) && v[inner].is_a?(Array)
+              if @multi_exec_indices.include?(outer) && v[inner].is_a?(Array)
                 v[inner].each do |result|
                   if result.is_a?(::RedisClient::CommandError)
                     errors ||= {}

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -239,7 +239,6 @@ class RedisClient
 
         work_group.close
         @router.renew_cluster_state if cluster_state_errors
-        raise ::RedisClient::Cluster::ErrorCollection.with_errors(errors).with_config(@router.config) unless errors.nil?
 
         required_redirections&.each do |node_key, v|
           all_replies ||= Array.new(@size)
@@ -252,7 +251,13 @@ class RedisClient
               next if redirected_segments.include?(key)
 
               redirected_segments.add(key)
-              v.replies[segment.end] = handle_redirection(node_key, v.replies[i], pipeline, i)
+              v.replies[segment.end] = handle_redirection(node_key, v.replies[i], pipeline, i).map do |result|
+                if @exception && result.is_a?(::RedisClient::CommandError)
+                  errors ||= {}
+                  errors[node_key] = result
+                end
+                result
+              end
             else
               v.replies[i] = handle_redirection(node_key, v.replies[i], pipeline, i)
             end
@@ -268,6 +273,7 @@ class RedisClient
           all_replies ||= Array.new(@size)
           @pipelines[node_key].outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
         end
+        raise ::RedisClient::Cluster::ErrorCollection.with_errors(errors).with_config(@router.config) unless errors.nil?
 
         all_replies
       end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -168,7 +168,8 @@ class RedisClient
       def multi
         transaction = ::RedisClient::Cluster::Transaction.new(@router, @command_builder)
         yield transaction
-        raise ConsistencyError.new('unable to determine slot').with_config(@router.config) if transaction.node_key.nil?
+        slots = transaction.pipeline._commands.map { |command| @router.find_slot(command) }.compact.uniq
+        raise ::RedisClient::Cluster::Transaction::ConsistencyError.new('unable to determine slot').with_config(@router.config) if transaction.node_key.nil? || slots.size != 1
 
         transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
           append_pipeline_noreply(transaction.node_key).call_once_v(command, &block)

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -128,6 +128,7 @@ class RedisClient
         @pipelines = nil
         @size = 0
         @multi_exec_indices = Set.new
+        @multi_exec_segments = {}
       end
 
       def call(*args, **kwargs, &block)
@@ -174,10 +175,17 @@ class RedisClient
 
         @multi_exec_indices.add(@size)
 
+        node_key = transaction.node_key
+        inner_lo = (@pipelines || {})[node_key]&.size || 0
+
         transaction.pipeline._commands.zip(transaction.pipeline._blocks || []).each do |command, block|
-          append_pipeline_noreply(transaction.node_key).call_once_v(command, &block)
+          append_pipeline_noreply(node_key).call_once_v(command, &block)
         end
-        append_pipeline(transaction.node_key).call_once('EXEC')
+        append_pipeline(node_key).call_once('EXEC')
+
+        inner_hi = @pipelines[node_key]._size - 1
+        @multi_exec_segments[node_key] ||= []
+        @multi_exec_segments[node_key] << (inner_lo..inner_hi)
       end
 
       def empty?
@@ -237,7 +245,7 @@ class RedisClient
 
           all_replies ||= Array.new(@size)
           pipeline = @pipelines[node_key]
-          v.indices.each { |i| v.replies[i] = handle_redirection(v.replies[i], pipeline, i) }
+          v.indices.each { |i| v.replies[i] = handle_redirection(node_key, v.replies[i], pipeline, i) }
           pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
         end
 
@@ -290,22 +298,22 @@ class RedisClient
         pipeline._coerce!(results)
       end
 
-      def handle_redirection(err, pipeline, inner_index)
+      def handle_redirection(node_key, err, pipeline, inner_index)
         return err unless err.is_a?(::RedisClient::CommandError)
 
         if err.message.start_with?('MOVED')
           node = @router.assign_redirection_node(err.message)
-          try_redirection(node, pipeline, inner_index)
+          try_redirection(node_key, node, pipeline, inner_index)
         elsif err.message.start_with?('ASK')
           node = @router.assign_asking_node(err.message)
-          try_asking(node) ? try_redirection(node, pipeline, inner_index) : err
+          try_asking(node) ? try_redirection(node_key, node, pipeline, inner_index) : err
         else
           err
         end
       end
 
-      def try_redirection(node, pipeline, inner_index)
-        redirect_command(node, pipeline, inner_index)
+      def try_redirection(node_key, node, pipeline, inner_index)
+        redirect_command(node, pipeline, inner_index) unless (@multi_exec_segments[node_key] || []).any? { |segment| segment.include?(inner_index) }
       rescue StandardError => e
         @exception ? raise : e
       end

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -223,7 +223,7 @@ class RedisClient
           else
             all_replies ||= Array.new(@size)
             @pipelines[node_key].outer_indices.each_with_index do |outer, inner|
-              if @multi_exec_indices.include?(outer) && v[inner].is_a?(Array)
+              if @exception && @multi_exec_indices.include?(outer) && v[inner].is_a?(Array)
                 v[inner].each do |result|
                   if result.is_a?(::RedisClient::CommandError)
                     errors ||= {}

--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -9,6 +9,7 @@ class RedisClient
   class Cluster
     class Transaction
       ConsistencyError = Class.new(::RedisClient::Cluster::Error)
+      attr_reader :node_key, :pipeline
 
       MAX_REDIRECTION = 2
       EMPTY_ARRAY = [].freeze
@@ -84,10 +85,10 @@ class RedisClient
       def prepare(command)
         return true unless @node.nil?
 
-        node_key = @router.find_primary_node_key(command)
-        return false if node_key.nil?
+        @node_key = @router.find_primary_node_key(command)
+        return false if @node_key.nil?
 
-        @node = @router.find_node(node_key)
+        @node = @router.find_node(@node_key)
         prepare_tx
         true
       end

--- a/test/middlewares/multi_exec_only.rb
+++ b/test/middlewares/multi_exec_only.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Middlewares
+  # Drops pipelined commands outside MULTI/EXEC spans on the wire so tests can
+  # assert end state only changes when the full transaction reached Redis.
+  module MultiExecOnly
+    module Injected
+      def write_multi(commands)
+        state = multi_exec_only_state
+        return super unless state
+
+        state[:dropped] = []
+        wire_commands = []
+        in_transaction = false
+
+        commands.each_with_index do |cmd, index|
+          name = cmd[0].to_s.downcase
+          if name == 'multi'
+            in_transaction = true
+            wire_commands << cmd
+          elsif in_transaction
+            wire_commands << cmd
+            in_transaction = false if name == 'exec'
+          else
+            state[:dropped] << index
+          end
+        end
+        state[:position] = 0
+
+        super(wire_commands) unless wire_commands.empty?
+        nil
+      end
+
+      def read(timeout = nil)
+        state = multi_exec_only_state
+        return super(timeout) unless state
+
+        state[:position] += 1
+        if state[:dropped].include?(state[:position] - 1)
+          nil
+        else
+          super(timeout)
+        end
+      end
+
+      private
+
+      def multi_exec_only_state
+        return nil unless Thread.current[:multi_exec_only_enabled]
+
+        registry = Thread.current[:multi_exec_only_registry] ||= {}
+        registry[self] ||= { dropped: [], position: 0 }
+      end
+    end
+
+    module_function
+
+    def install!
+      return if @installed
+
+      ::RedisClient::RubyConnection.prepend(Injected)
+      @installed = true
+    end
+
+    def with
+      install!
+      Thread.current[:multi_exec_only_enabled] = true
+      Thread.current[:multi_exec_only_registry] = {}
+      yield
+    ensure
+      Thread.current[:multi_exec_only_enabled] = nil
+      Thread.current[:multi_exec_only_registry] = nil
+    end
+  end
+end

--- a/test/middlewares/redirect_read_inject.rb
+++ b/test/middlewares/redirect_read_inject.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Middlewares
+  # Drops matching commands on the wire and returns MOVED on +read+ so cluster
+  # +call_pipelined_aware_of_redirection+ handles redirection like a real node.
+  # When the match falls inside MULTI/EXEC, EXEC is replaced with DISCARD on the wire
+  # (so the connection is not left in MULTI) and the EXEC reply is replaced with EXECABORT.
+  module RedirectReadInject
+    Setting = Struct.new(
+      'RedirectReadInjectSetting',
+      :slot, :to, :command, :once, keyword_init: true
+    )
+
+    module Injected
+      def write_multi(commands)
+        context = Thread.current[:redirect_read_inject_context]
+        return super unless context
+
+        setting = context[:setting]
+        injections = []
+        wire_commands = []
+        in_transaction = false
+        matched_in_transaction = false
+
+        commands.each do |cmd|
+          name = cmd[0].to_s.downcase
+          if name == 'multi'
+            in_transaction = true
+            wire_commands << cmd
+            injections << nil
+          elsif name == 'exec'
+            if matched_in_transaction
+              wire_commands << %w[DISCARD]
+              injections << :execabort
+            else
+              wire_commands << cmd
+              injections << nil
+            end
+            in_transaction = false
+            matched_in_transaction = false
+          elsif ::Middlewares::RedirectReadInject.matching_command?(cmd, setting)
+            injections << :moved
+            matched_in_transaction = true if in_transaction
+          else
+            wire_commands << cmd
+            injections << nil
+          end
+        end
+
+        connection_registry[self] = {
+          injections: injections,
+          position: 0,
+          redirect_count: context[:redirect_count],
+          setting: setting
+        }
+        super(wire_commands) unless wire_commands.empty?
+        nil
+      end
+
+      def read(timeout = nil)
+        state = connection_registry[self]
+        return super(timeout) unless state
+
+        index = state[:position]
+        state[:position] += 1
+        injection = state[:injections][index]
+        case injection
+        when :moved
+          state[:redirect_count]&.moved
+          s = state[:setting]
+          ::RedisClient::CommandError.new("MOVED #{s.slot} #{s.to}")
+        when :execabort
+          super(timeout)
+          ::RedisClient::CommandError.new('EXECABORT')
+        else
+          super(timeout)
+        end
+      end
+
+      private
+
+      def connection_registry
+        Thread.current[:redirect_read_inject_registry] ||= {}
+      end
+    end
+
+    def call_pipelined(commands, cfg)
+      setting = cfg.custom[:redirect_read_inject]
+      return super unless setting
+
+      ::Middlewares::RedirectReadInject.install!
+      Thread.current[:redirect_read_inject_context] = {
+        setting: setting,
+        redirect_count: cfg.custom[:redirect_count]
+      }
+
+      super
+    ensure
+      Thread.current[:redirect_read_inject_context] = nil
+      Thread.current[:redirect_read_inject_registry] = nil
+    end
+
+    module_function
+
+    def install!
+      return if @installed
+
+      ::RedisClient::RubyConnection.prepend(Injected)
+      @installed = true
+    end
+
+    def matching_command?(cmd, setting)
+      return false unless cmd == setting.command
+
+      if setting.once
+        registry = Thread.current[:redirect_read_inject_once] ||= {}
+        return false if registry[setting]
+
+        registry[setting] = true
+      end
+
+      true
+    end
+  end
+end

--- a/test/middlewares/redirect_read_inject.rb
+++ b/test/middlewares/redirect_read_inject.rb
@@ -96,8 +96,7 @@ module Middlewares
 
       super
     ensure
-      Thread.current[:redirect_read_inject_context] = nil
-      Thread.current[:redirect_read_inject_registry] = nil
+      ::Middlewares::RedirectReadInject.clear_active_inject_state!
     end
 
     module_function
@@ -107,6 +106,25 @@ module Middlewares
 
       ::RedisClient::RubyConnection.prepend(Injected)
       @installed = true
+    end
+
+    # Resets per-setting MOVED injection tracking. +once+ state persists across
+    # +pipelined+ calls within the block (not cleared per +call_pipelined+).
+    def with
+      install!
+      clear_redirect_counts!
+      yield
+    ensure
+      clear_redirect_counts!
+    end
+
+    def clear_active_inject_state!
+      Thread.current[:redirect_read_inject_context] = nil
+      Thread.current[:redirect_read_inject_registry] = nil
+    end
+
+    def clear_redirect_counts!
+      Thread.current[:redirect_read_inject_once] = nil
     end
 
     def matching_command?(cmd, setting)

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -221,6 +221,18 @@ class RedisClient
         assert_equal('2', @client.call('GET', 'counter'))
       end
 
+      def test_pipelined_transactions
+        got = @client.pipelined do |pipeline|
+          10.times do |i|
+            pipeline.multi do |multi|
+              multi.call('INCR', "string#{i}")
+              multi.call('INCRBY', "string#{i}", 2)
+            end
+          end
+        end
+        assert_equal(Array.new(10) { [1, 3] }, got)
+      end
+
       def test_transaction_with_multiple_key
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi do |t|

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -164,7 +164,7 @@ class RedisClient
       end
 
       def test_pipelined_with_errors
-        assert_raises(RedisClient::Cluster::ErrorCollection) do
+        err = assert_raises(RedisClient::Cluster::ErrorCollection) do
           @client.pipelined do |pipeline|
             10.times do |i|
               pipeline.call('SET', "string#{i}", i)
@@ -172,6 +172,11 @@ class RedisClient
               pipeline.call('SET', "string#{i}", i + 10)
             end
           end
+        end
+
+        refute_empty(err.errors)
+        err.errors.each_value do |e|
+          assert_instance_of(::RedisClient::CommandError, e)
         end
 
         wait_for_replication

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -249,6 +249,26 @@ class RedisClient
         end
       end
 
+      def test_pipelined_transactions_with_command_errors
+        assert_raises(::RedisClient::Cluster::ErrorCollection) do
+          @client.pipelined do |pipeline|
+            10.times do |i|
+              pipeline.multi do |multi|
+                multi.call('SET', "string#{i}", i)
+                multi.call('SET', "string#{i}", i, 'too many args')
+                multi.call('SET', "string#{i}", i + 10)
+              end
+            end
+          end
+        end
+
+        wait_for_replication
+
+        10.times do |i|
+          assert_equal((i + 10).to_s, @client.call('GET', "string#{i}"))
+        end
+      end
+
       def test_transaction_with_multiple_key
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi do |t|

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -326,27 +326,77 @@ class RedisClient
           }
         )
 
-        Thread.current[:redirect_read_inject_once] = nil
-        ::Middlewares::MultiExecOnly.with do
-          got = client.pipelined do |pipeline|
-            pipeline.call('SET', 'decoy', 'must-not-appear')
-            pipeline.multi do |multi|
-              multi.call('SET', key, '0')
-              multi.call('INCR', key)
+        got = nil
+        ::Middlewares::RedirectReadInject.with do
+          ::Middlewares::MultiExecOnly.with do
+            got = client.pipelined do |pipeline|
+              pipeline.call('SET', 'decoy', 'must-not-appear')
+              pipeline.multi do |multi|
+                multi.call('SET', key, '0')
+                multi.call('INCR', key)
+              end
+              pipeline.call('GET', 'decoy')
             end
-            pipeline.call('GET', 'decoy')
           end
-
-          refute(redirect_count.zero?, redirect_count.get)
-          assert_equal(3, got.size)
-          assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
-          assert_equal(['OK', 1], got[1])
-          assert_nil(got[2], 'decoy GET is dropped by MultiExecOnly and not sent to Redis')
-          assert_nil(client.call('GET', 'decoy'))
-          assert_equal('1', client.call('GET', key))
         end
+
+        refute(redirect_count.zero?, redirect_count.get)
+        assert_equal(3, got.size)
+        assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
+        assert_equal(['OK', 1], got[1])
+        assert_nil(got[2], 'decoy GET is dropped by MultiExecOnly and not sent to Redis')
+        assert_nil(client.call('GET', 'decoy'))
+        assert_equal('1', client.call('GET', key))
       ensure
-        Thread.current[:redirect_read_inject_once] = nil
+        client&.close
+      end
+
+      def test_pipelined_transaction_redirects_on_moved_with_errors
+        key = 'tx_redirect_err_key'
+        slot = ::RedisClient::Cluster::KeySlotConverter.convert(key)
+        router = @client.instance_variable_get(:@router)
+        target_node_key = router.find_node_key_by_key(key, primary: true)
+        redirect_count = ::Middlewares::RedirectCount::Counter.new
+
+        client = new_test_client(
+          middlewares: [
+            ::Middlewares::RedirectReadInject
+          ],
+          custom: {
+            redirect_count: redirect_count,
+            redirect_read_inject: ::Middlewares::RedirectReadInject::Setting.new(
+              slot: slot,
+              to: target_node_key,
+              command: %w[SET tx_redirect_err_key 0],
+              once: true
+            )
+          }
+        )
+
+        err = nil
+        ::Middlewares::RedirectReadInject.with do
+          ::Middlewares::MultiExecOnly.with do
+            err = assert_raises(::RedisClient::Cluster::ErrorCollection) do
+              client.pipelined do |pipeline|
+                pipeline.call('SET', 'decoy_err', 'must-not-appear')
+                pipeline.multi do |multi|
+                  multi.call('SET', key, '0')
+                  multi.call('SET', key, '0', 'too many args')
+                  multi.call('SET', key, '2')
+                end
+              end
+            end
+          end
+        end
+        refute(redirect_count.zero?, redirect_count.get)
+        assert_instance_of(::RedisClient::Cluster::ErrorCollection, err)
+        refute_empty(err.errors)
+        err.errors.each_value do |e|
+          assert_instance_of(::RedisClient::CommandError, e)
+        end
+        assert_nil(client.call('GET', 'decoy_err'))
+        assert_equal('2', client.call('GET', key))
+      ensure
         client&.close
       end
 
@@ -372,28 +422,28 @@ class RedisClient
           }
         )
 
-        Thread.current[:redirect_read_inject_once] = nil
-        ::Middlewares::MultiExecOnly.with do
-          got = client.pipelined(exception: false) do |pipeline|
-            pipeline.call('SET', 'decoy_err', 'must-not-appear')
-            pipeline.multi do |multi|
-              multi.call('SET', key, '0')
-              multi.call('SET', key, '0', 'too many args')
-              multi.call('SET', key, '2')
+        ::Middlewares::RedirectReadInject.with do
+          ::Middlewares::MultiExecOnly.with do
+            got = client.pipelined(exception: false) do |pipeline|
+              pipeline.call('SET', 'decoy_err', 'must-not-appear')
+              pipeline.multi do |multi|
+                multi.call('SET', key, '0')
+                multi.call('SET', key, '0', 'too many args')
+                multi.call('SET', key, '2')
+              end
             end
-          end
 
-          refute(redirect_count.zero?, redirect_count.get)
-          assert_equal(2, got.size)
-          assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
-          assert_equal('OK', got[1][0])
-          assert_instance_of(::RedisClient::CommandError, got[1][1])
-          assert_equal('OK', got[1][2])
-          assert_nil(client.call('GET', 'decoy_err'))
-          assert_equal('2', client.call('GET', key))
+            refute(redirect_count.zero?, redirect_count.get)
+            assert_equal(2, got.size)
+            assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
+            assert_equal('OK', got[1][0])
+            assert_instance_of(::RedisClient::CommandError, got[1][1])
+            assert_equal('OK', got[1][2])
+            assert_nil(client.call('GET', 'decoy_err'))
+            assert_equal('2', client.call('GET', key))
+          end
         end
       ensure
-        Thread.current[:redirect_read_inject_once] = nil
         client&.close
       end
 

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -255,7 +255,7 @@ class RedisClient
       end
 
       def test_pipelined_transactions_with_command_errors
-        assert_raises(::RedisClient::Cluster::ErrorCollection) do
+        err = assert_raises(::RedisClient::Cluster::ErrorCollection) do
           @client.pipelined do |pipeline|
             10.times do |i|
               pipeline.multi do |multi|
@@ -265,6 +265,36 @@ class RedisClient
               end
             end
           end
+        end
+
+        refute_empty(err.errors)
+        err.errors.each_value do |e|
+          assert_instance_of(::RedisClient::CommandError, e)
+        end
+
+        wait_for_replication
+
+        10.times do |i|
+          assert_equal((i + 10).to_s, @client.call('GET', "string#{i}"))
+        end
+      end
+
+      def test_pipelined_transactions_with_command_errors_as_is
+        got = @client.pipelined(exception: false) do |pipeline|
+          10.times do |i|
+            pipeline.multi do |multi|
+              multi.call('SET', "string#{i}", i)
+              multi.call('SET', "string#{i}", i, 'too many args')
+              multi.call('SET', "string#{i}", i + 10)
+            end
+          end
+        end
+
+        assert_equal(10, got.size)
+        got.each do |result|
+          assert_equal('OK', result[0])
+          assert_instance_of(::RedisClient::CommandError, result[1])
+          assert_equal('OK', result[2])
         end
 
         wait_for_replication

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -233,6 +233,22 @@ class RedisClient
         assert_equal(Array.new(10) { [1, 3] }, got)
       end
 
+      def test_pipelined_transactions_with_multiple_key
+        assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
+          @client.pipelined do |pipeline|
+            pipeline.multi do |multi|
+              multi.call('SET', 'key1', '1')
+              multi.call('SET', 'key2', '2')
+              multi.call('SET', 'key3', '3')
+            end
+          end
+        end
+
+        (1..3).each do |i|
+          assert_nil(@client.call('GET', "key#{i}"))
+        end
+      end
+
       def test_transaction_with_multiple_key
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi do |t|

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -304,6 +304,99 @@ class RedisClient
         end
       end
 
+      def test_pipelined_transaction_redirects_on_moved
+        key = 'tx_redirect_key'
+        slot = ::RedisClient::Cluster::KeySlotConverter.convert(key)
+        router = @client.instance_variable_get(:@router)
+        target_node_key = router.find_node_key_by_key(key, primary: true)
+        redirect_count = ::Middlewares::RedirectCount::Counter.new
+
+        client = new_test_client(
+          middlewares: [
+            ::Middlewares::RedirectReadInject
+          ],
+          custom: {
+            redirect_count: redirect_count,
+            redirect_read_inject: ::Middlewares::RedirectReadInject::Setting.new(
+              slot: slot,
+              to: target_node_key,
+              command: %w[SET tx_redirect_key 0],
+              once: true
+            )
+          }
+        )
+
+        Thread.current[:redirect_read_inject_once] = nil
+        ::Middlewares::MultiExecOnly.with do
+          got = client.pipelined do |pipeline|
+            pipeline.call('SET', 'decoy', 'must-not-appear')
+            pipeline.multi do |multi|
+              multi.call('SET', key, '0')
+              multi.call('INCR', key)
+            end
+            pipeline.call('GET', 'decoy')
+          end
+
+          refute(redirect_count.zero?, redirect_count.get)
+          assert_equal(3, got.size)
+          assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
+          assert_equal(['OK', 1], got[1])
+          assert_nil(got[2], 'decoy GET is dropped by MultiExecOnly and not sent to Redis')
+          assert_nil(client.call('GET', 'decoy'))
+          assert_equal('1', client.call('GET', key))
+        end
+      ensure
+        Thread.current[:redirect_read_inject_once] = nil
+        client&.close
+      end
+
+      def test_pipelined_transaction_redirects_on_moved_as_is
+        key = 'tx_redirect_err_key'
+        slot = ::RedisClient::Cluster::KeySlotConverter.convert(key)
+        router = @client.instance_variable_get(:@router)
+        target_node_key = router.find_node_key_by_key(key, primary: true)
+        redirect_count = ::Middlewares::RedirectCount::Counter.new
+
+        client = new_test_client(
+          middlewares: [
+            ::Middlewares::RedirectReadInject
+          ],
+          custom: {
+            redirect_count: redirect_count,
+            redirect_read_inject: ::Middlewares::RedirectReadInject::Setting.new(
+              slot: slot,
+              to: target_node_key,
+              command: %w[SET tx_redirect_err_key 0],
+              once: true
+            )
+          }
+        )
+
+        Thread.current[:redirect_read_inject_once] = nil
+        ::Middlewares::MultiExecOnly.with do
+          got = client.pipelined(exception: false) do |pipeline|
+            pipeline.call('SET', 'decoy_err', 'must-not-appear')
+            pipeline.multi do |multi|
+              multi.call('SET', key, '0')
+              multi.call('SET', key, '0', 'too many args')
+              multi.call('SET', key, '2')
+            end
+          end
+
+          refute(redirect_count.zero?, redirect_count.get)
+          assert_equal(2, got.size)
+          assert_nil(got[0], 'decoy SET is dropped by MultiExecOnly and not sent to Redis')
+          assert_equal('OK', got[1][0])
+          assert_instance_of(::RedisClient::CommandError, got[1][1])
+          assert_equal('OK', got[1][2])
+          assert_nil(client.call('GET', 'decoy_err'))
+          assert_equal('2', client.call('GET', key))
+        end
+      ensure
+        Thread.current[:redirect_read_inject_once] = nil
+        client&.close
+      end
+
       def test_transaction_with_multiple_key
         assert_raises(::RedisClient::Cluster::Transaction::ConsistencyError) do
           @client.multi do |t|

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -221,22 +221,20 @@ module TestAgainstClusterState
         moved_keys = keys
       end
 
-      error = assert_raises(::RedisClient::CommandError) do
-        @client.pipelined do |pipeline|
-          moved_keys.each do |key|
-            pipeline.multi do |multi|
-              multi.call('SET', key, '0')
-              multi.call('INCR', key)
-              multi.call('INCRBY', key, 2)
-            end
+      @client.pipelined do |pipeline|
+        moved_keys.each do |key|
+          pipeline.multi do |multi|
+            multi.call('SET', key, '0')
+            multi.call('INCR', key)
+            multi.call('INCRBY', key, 2)
           end
         end
       end
 
-      assert_match(/^EXECABORT/, error.message)
+      wait_for_replication
 
       moved_keys.each do |key|
-        assert_equal(key, @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
+        assert_equal('3', @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
       end
     end
 
@@ -245,21 +243,20 @@ module TestAgainstClusterState
       do_resharding_test(number_of_keys: 200) do |keys|
         sample = keys.first(10)
 
-        error = assert_raises(::RedisClient::CommandError) do
-          @client.pipelined do |pipeline|
-            sample.each do |key|
-              pipeline.multi do |multi|
-                multi.call('SET', key, '0')
-                multi.call('INCR', key)
-                multi.call('INCRBY', key, 2)
-              end
+        @client.pipelined do |pipeline|
+          sample.each do |key|
+            pipeline.multi do |multi|
+              multi.call('SET', key, '0')
+              multi.call('INCR', key)
+              multi.call('INCRBY', key, 2)
             end
           end
         end
-        assert_match(/^EXECABORT/, error.message)
+
+        wait_for_replication
 
         sample.each do |key|
-          assert_equal(key, @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
+          assert_equal('3', @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
         end
       end
     end

--- a/test/test_against_cluster_state.rb
+++ b/test/test_against_cluster_state.rb
@@ -214,6 +214,56 @@ module TestAgainstClusterState
       end
     end
 
+    def test_the_state_of_cluster_resharding_with_pipelined_transactions_after_moved
+      # Tests that multis within pipelines get redirected properly.
+      moved_keys = nil
+      do_resharding_test(number_of_keys: 200) do |keys|
+        moved_keys = keys
+      end
+
+      error = assert_raises(::RedisClient::CommandError) do
+        @client.pipelined do |pipeline|
+          moved_keys.each do |key|
+            pipeline.multi do |multi|
+              multi.call('SET', key, '0')
+              multi.call('INCR', key)
+              multi.call('INCRBY', key, 2)
+            end
+          end
+        end
+      end
+
+      assert_match(/^EXECABORT/, error.message)
+
+      moved_keys.each do |key|
+        assert_equal(key, @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
+      end
+    end
+
+    def test_the_state_of_cluster_resharding_with_pipelined_transactions_during_slot_migration_ask
+      # Tests that multis within pipelines get redirected properly.
+      do_resharding_test(number_of_keys: 200) do |keys|
+        sample = keys.first(10)
+
+        error = assert_raises(::RedisClient::CommandError) do
+          @client.pipelined do |pipeline|
+            sample.each do |key|
+              pipeline.multi do |multi|
+                multi.call('SET', key, '0')
+                multi.call('INCR', key)
+                multi.call('INCRBY', key, 2)
+              end
+            end
+          end
+        end
+        assert_match(/^EXECABORT/, error.message)
+
+        sample.each do |key|
+          assert_equal(key, @client.call('GET', key), "Case: GET after pipelined multi: #{key}")
+        end
+      end
+    end
+
     private
 
     def wait_for_replication

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -8,7 +8,9 @@ require 'testing_constants'
 require 'cluster_controller'
 require 'middlewares/command_capture'
 require 'middlewares/redirect_count'
+require 'middlewares/redirect_read_inject'
 require 'middlewares/redirect_fake'
+require 'middlewares/multi_exec_only'
 
 case ENV.fetch('REDIS_CONNECTION_DRIVER', 'ruby')
 when 'hiredis' then require 'hiredis-client'


### PR DESCRIPTION
This adds transactional support with pipelining.

```
client.pipelined do |pipeline|
  pipeline.multi do |multi|
    multi.call(...)
  end
end
```

Will perform all calls within the multi around a MULTI/EXEC within the pipeline to provide transactional guarantees.

Will raise a consistency error if all keys within the multi do not align to the same node key.

When exception is true in the pipeline, will search through the EXEC results and raise any errors found within (wrapped in an ErrorCollection).

Also handles automatic redirection of the entire transaction when a MOVE or ASK is encountered.

Note this does not support adding watches, it is intended solely to enable atomicity within pipelines.