### PR TITLE
fix: seed is not propagated to replica selection

### DIFF
--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -227,7 +227,7 @@ class RedisClient
       def find_node_key_by_key(key, seed: nil, primary: false)
         if key && !key.empty?
           slot = ::RedisClient::Cluster::KeySlotConverter.convert(key)
-          node_key = primary ? @node.find_node_key_of_primary(slot) : @node.find_node_key_of_replica(slot)
+          node_key = primary ? @node.find_node_key_of_primary(slot) : @node.find_node_key_of_replica(slot, seed: seed)
           if node_key.nil?
             renew_cluster_state
             raise ::RedisClient::Cluster::NodeMightBeDown.new.with_config(@config)


### PR DESCRIPTION
`router.rb:230` — `find_node_key_by_key` calls `@node.find_node_key_of_replica(slot)` without `seed: seed` on the keyed path. Before 31968f375fa67fc89855eeb4ffb5be57473059c6 the seed was passed (`find_node_key_of_replica(slot, seed: seed)`).

`Cluster::Pipeline` passes `seed: @seed` with every command so that commands for the same slot stick to one replica within a pipeline (see the OPTIMIZE comment in `node/base_topology.rb`), but since the seed is dropped here, each command samples a replica with the global `Random`. A single pipeline can therefore split into more per-node sub-pipelines than necessary, and the `Random.new_seed` computed per `#pipelined` / split `MGET`/`MSET`/`DEL` is effectively wasted. One-line fix.