### PR TITLE
fix: Transaction#handle_command_error! returns the error object instead of raising when ASK fails

### DIFF
--- a/lib/redis_client/cluster/transaction.rb
+++ b/lib/redis_client/cluster/transaction.rb
@@ -171,7 +171,7 @@ class RedisClient
           send_transaction(node, redirect: redirect - 1)
         elsif err.message.start_with?('ASK')
           node = @router.assign_asking_node(err.message)
-          try_asking(node) ? send_transaction(node, redirect: redirect - 1) : err
+          try_asking(node) ? send_transaction(node, redirect: redirect - 1) : raise(err)
         elsif err.message.start_with?('CLUSTERDOWN')
           @router.renew_cluster_state if @watching_slot.nil?
           raise err


### PR DESCRIPTION
`transaction.rb:174` — on the ASK branch, `try_asking(node) ? send_transaction(...) : err` returns `err`. The value propagates through `send_pipeline` → `execute`, so `#multi` can return a `CommandError` instance as its return value instead of raising. The "return err" pattern is correct in `Pipeline#handle_redirection` (errors are embedded into replies), but in `Transaction` it should be `raise err`.
