### PR TITLE
fix: cluster-state reload closes live topology clients in the default path

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -314,7 +314,6 @@ class RedisClient
             e
           ensure
             client.read_timeout = regular_timeout
-            client&.close
           end
         end
 


### PR DESCRIPTION
`node.rb:317` — `refetch_node_info_list` closes every startup client in `ensure`. With the default `connect_with_original_config: false`, `with_startup_clients` yields clients sampled from the live topology (`node.rb:494`), so every reload tears down connections of up to `max_startup_sample` healthy nodes. With `pool:` those are `RedisClient::Pooled`, whose `#close` shuts the whole pool down (the pool is lazily re-created afterwards, so it is not permanent, but all warm connections are dropped).