### PR TITLE
fix: CharArray empty-slot sentinel collides with element index 48 (>=49 primaries)

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -53,15 +53,10 @@ class RedisClient
       end
 
       class CharArray
-        BASE = ''
-        PADDING = '0'
-
-        private_constant :BASE, :PADDING
-
         def initialize(size, elements)
           @elements = elements
-          @string = String.new(BASE, encoding: Encoding::BINARY, capacity: size)
-          size.times { @string << PADDING }
+          @string = String.new('', encoding: Encoding::BINARY, capacity: size)
+          size.times { @string << 0xff }
         end
 
         def [](index)


### PR DESCRIPTION
`node.rb:55-88` — `CharArray` fills the backing string with `'0'` (byte 48) as the "unassigned" marker, and `#[]` returns `@elements[@string.getbyte(index)]`. With ≤48 primaries `@elements[48]` is `nil` (correct), but with 49+ primaries an unassigned slot returns the 49th primary's node key instead of `nil`, silently routing commands for unassigned slots to a wrong node (mostly masked by MOVED handling, but it should surface as `NodeMightBeDown`). The Array fallback in `update_slot`'s `RangeError` path copies the aliased values too.