### PR TITLE
chore: fix some issues

### DIFF
--- a/lib/redis_client/cluster/optimistic_locking.rb
+++ b/lib/redis_client/cluster/optimistic_locking.rb
@@ -2,6 +2,7 @@
 
 require 'redis_client'
 require 'redis_client/cluster/transaction'
+require 'redis_client/cluster/error_identification'
 
 class RedisClient
   class Cluster
@@ -54,7 +55,7 @@ class RedisClient
       rescue ::RedisClient::ConnectionError
         # Deduct the number of retries that happened _inside_ router#handle_redirection from our remaining
         # _external_ retries. Always deduct at least one in case handle_redirection raises without trying the block.
-        retry_count -= times_block_executed == 0 ? 1 : [times_block_executed, 1].min
+        retry_count -= [times_block_executed, 1].max
         raise if retry_count < 0
 
         retry

--- a/lib/redis_client/cluster/optimistic_locking.rb
+++ b/lib/redis_client/cluster/optimistic_locking.rb
@@ -55,7 +55,7 @@ class RedisClient
       rescue ::RedisClient::ConnectionError
         # Deduct the number of retries that happened _inside_ router#handle_redirection from our remaining
         # _external_ retries. Always deduct at least one in case handle_redirection raises without trying the block.
-        retry_count -= [times_block_executed, 1].max
+        retry_count -= times_block_executed == 0 ? 1 : [times_block_executed, 1].min
         raise if retry_count < 0
 
         retry

--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -23,10 +23,6 @@ class RedisClient
           @outer_indices << index
         end
 
-        def get_inner_index(outer_index)
-          @outer_indices&.find_index(outer_index)
-        end
-
         def get_callee_method(inner_index)
           if @timeouts.is_a?(Array) && !@timeouts[inner_index].nil?
             :blocking_call_v
@@ -66,6 +62,7 @@ class RedisClient
             if result.is_a?(::RedisClient::Error)
               result._set_command(commands[index])
               result._set_config(config)
+              result._set_retry_attempt(@retry_attempt)
 
               if result.is_a?(::RedisClient::CommandError) && result.message.start_with?('MOVED', 'ASK')
                 redirection_indices ||= []


### PR DESCRIPTION
* `optimistic_locking.rb:66` references `ErrorIdentification` but the file doesn't `require 'redis_client/cluster/error_identification'` (works only due to load order via `router.rb`).
* `pipeline.rb:26` — `Extended#get_inner_index` is dead code.
* `call_pipelined_aware_of_redirection` has drifted from upstream `ConnectionMixin#call_pipelined` (no `_set_retry_attempt`, no config propagation into Array (MULTI) results).
* ~Retry deduction in `OptimisticLocking#handle_redirection` doesn't match the comment~
  * ~`optimistic_locking.rb:57` — `times_block_executed == 0 ? 1 : [times_block_executed, 1].min` always evaluates to `1`. The comment says the inner retry count should be deducted, which would be `.max`. As-is, more retries happen than the comment intends, each preceded by an expensive `renew_cluster_state`. Either simplify to `retry_count -= 1` and fix the comment, or use `.max`. (Follow-up to redis-rb/redis-cluster-client#499.)~