### PR TITLE
fix: retry deduction in OptimisticLocking#handle_redirection doesn't match the comment

### DIFF
--- a/lib/redis_client/cluster/optimistic_locking.rb
+++ b/lib/redis_client/cluster/optimistic_locking.rb
@@ -55,7 +55,7 @@ class RedisClient
       rescue ::RedisClient::ConnectionError
         # Deduct the number of retries that happened _inside_ router#handle_redirection from our remaining
         # _external_ retries. Always deduct at least one in case handle_redirection raises without trying the block.
-        retry_count -= times_block_executed == 0 ? 1 : [times_block_executed, 1].min
+        retry_count -= times_block_executed > 1 ? times_block_executed : 1
         raise if retry_count < 0
 
         retry

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -167,19 +167,20 @@ class RedisClient
         raise unless ::RedisClient::Cluster::ErrorIdentification.client_owns_error?(e, node)
 
         renew_cluster_state
-        retry_count -= 1
+        raise if command.nil? || command.empty?
 
-        if retry_count >= 0
-          # Find the node to use for this command - if this fails for some reason, though, re-use
-          # the old node.
-          begin
-            node = find_node(find_node_key(command)) if command
-          rescue StandardError # rubocop:disable Lint/SuppressedException
-          end
-          retry
+        retry_count -= 1
+        raise if retry_count < 0
+
+        # Find the node to use for this command - if this fails for some reason, though, re-use
+        # the old node.
+        begin
+          node = find_node(find_node_key(command))
+        rescue StandardError
+          raise e
         end
 
-        raise
+        retry
       end
 
       def scan(command, seed: nil) # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
`optimistic_locking.rb:57` — `times_block_executed == 0 ? 1 : [times_block_executed, 1].min` always evaluates to `1`. The comment says the inner retry count should be deducted, which would be `.max`. As-is, more retries happen than the comment intends, each preceded by an expensive `renew_cluster_state`. Either simplify to `retry_count -= 1` and fix the comment, or use `.max`. (Follow-up to redis-rb/redis-cluster-client#499.)