### PR TITLE
ci: temporarily pin the rbs version for JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'logger'
 gem 'memory_profiler'
 gem 'minitest'
 gem 'rake'
+gem 'rbs', '4.1.0.pre.2' if RUBY_ENGINE == 'jruby' # FIXME: https://github.com/ruby/rdoc/issues/1746
 gem 'rubocop'
 gem 'rubocop-minitest', require: false
 gem 'rubocop-performance', require: false


### PR DESCRIPTION
```
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.

In Gemfile:
  irb was resolved to 1.18.0, which depends on
    rdoc was resolved to 8.0.0, which depends on
      rbs
Error: The process '/home/runner/.rubies/jruby-10.1.0.0/bin/bundle' failed with exit code 5
```

* https://github.com/ruby/rdoc/issues/1746