### PR TITLE
fix: "undefined method `fetch' for nil" when shard has no master

### DIFF
--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -403,7 +403,7 @@ class RedisClient
           shard = shard.each_slice(2).to_h if resp2
           nodes = shard.fetch('nodes')
           nodes = nodes.map { |n| n.each_slice(2).to_h } if resp2
-          primary_id = nodes.find { |n| n.fetch('role') == 'master' }&.fetch('id')
+          primary_id = nodes.find { |n| n.fetch('role') == 'master' }&.fetch('id') || EMPTY_STRING
 
           nodes.each do |node|
             host = pick_shard_host(node)

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -403,7 +403,7 @@ class RedisClient
           shard = shard.each_slice(2).to_h if resp2
           nodes = shard.fetch('nodes')
           nodes = nodes.map { |n| n.each_slice(2).to_h } if resp2
-          primary_id = nodes.find { |n| n.fetch('role') == 'master' }.fetch('id')
+          primary_id = nodes.find { |n| n.fetch('role') == 'master' }&.fetch('id')
 
           nodes.each do |node|
             host = pick_shard_host(node)

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -614,7 +614,7 @@ class RedisClient
 
         assert_equal(%w[127.0.0.1:16384], got.map(&:node_key))
         assert_equal(%w[slave], got.map(&:role))
-        assert(got.all? { |info| info.primary_id.nil? })
+        assert_equal([''], got.map(&:primary_id))
       end
 
       def test_inspect

--- a/test/redis_client/cluster/test_node.rb
+++ b/test/redis_client/cluster/test_node.rb
@@ -592,6 +592,31 @@ class RedisClient
         assert_equal(['10.0.0.1:6379'], got.map(&:node_key))
       end
 
+      def test_parse_cluster_shards_reply_without_master
+        reply = [
+          [
+            'slots', [],
+            'nodes', [
+              [
+                'id', 'beeb7f1c33cde531e290c32c830f2401ab1b8dea',
+                'port', 16_384,
+                'ip', '127.0.0.1',
+                'endpoint', '127.0.0.1',
+                'role', 'replica',
+                'replication-offset', 642_515,
+                'health', 'online'
+              ]
+            ]
+          ]
+        ]
+
+        got = @test_node.send(:parse_cluster_shards_reply, reply)
+
+        assert_equal(%w[127.0.0.1:16384], got.map(&:node_key))
+        assert_equal(%w[slave], got.map(&:role))
+        assert(got.all? { |info| info.primary_id.nil? })
+      end
+
       def test_inspect
         assert_match(/^#<RedisClient::Cluster::Node [0-9., :]*>$/, @test_node.inspect)
       end


### PR DESCRIPTION
There could be cases where a shard ~has~ reports no master nodes. Not a good state, but still, the app can still operate. We are still investigating why our Redis went into this weird state.

A bug was introduced in https://github.com/redis-rb/redis-cluster-client/pull/479 (v0.16.0), where previously a similar state would not cause an exception.

EDIT: We bumped Redis from 7.2.7 to 7.2.14 and they stopped reporting fake shards. Not sure which version fixed it.