### PR TITLE
fix: follow the subcommands and the command tips of the COMMAND reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ The `#multi` method supports the transaction feature but you should use a hashta
 The `#pubsub` method supports sharded subscriptions.
 Every interface handles redirections and resharding states internally.
 
+## Command routing
+This gem calls the [COMMAND](https://redis.io/commands/command) command on startup and decides
+which node each command should be sent to according to the reply.
+
+* The key positions of the subcommands of a container command such as `XINFO STREAM` are used
+  if the server reports them. It's available in the Redis 7.0 or later.
+* The [command tips](https://redis.io/docs/latest/develop/reference/command-tips/) are used
+  if the server reports them. It's available in the Redis 7.0 or later.
+  A command with `request_policy:all_shards` is sent to every primary node,
+  and a command with `request_policy:all_nodes` is sent to every node.
+  The replies are aggregated according to the `response_policy` tip.
+  It means that a newly added command such as `FUNCTION LOAD` is routed correctly
+  without waiting for a new release of this gem.
+
+The following cases fall back to the built-in table of this gem:
+
+* The Redis 6.2 or earlier which doesn't report the above information.
+* The commands which this gem handles in its own way such as `SCAN`, `KEYS` and `CLUSTER`.
+* The `request_policy:multi_shard` and the `request_policy:special` tips.
+* The `response_policy:special` tip. Such a command is sent to a single node as before
+  because the aggregation of the replies is undefined.
+  For example, `INFO` still returns the reply of a single node.
+
 ## Multiple keys and CROSSSLOT error
 A subset of commands can be passed multiple keys.
 In cluster mode, these commands have a constraint that passed keys should belong to the same slot

--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -9,15 +9,25 @@ class RedisClient
     class Command
       EMPTY_STRING = ''
       EMPTY_HASH = {}.freeze
+      EMPTY_POLICIES = [nil, nil].freeze
+      REQUEST_POLICY_PREFIX = 'request_policy:'
+      RESPONSE_POLICY_PREFIX = 'response_policy:'
+      SUBCOMMAND_DELIMITER = '|'
 
-      private_constant :EMPTY_HASH
+      private_constant :EMPTY_HASH, :EMPTY_POLICIES, :REQUEST_POLICY_PREFIX,
+                       :RESPONSE_POLICY_PREFIX, :SUBCOMMAND_DELIMITER
 
+      # @see https://redis.io/docs/latest/commands/command/ The reply of the COMMAND command
+      # @see https://redis.io/docs/latest/develop/reference/command-tips/ Command tips
       Spec = Struct.new(
         'RedisCommandSpec',
         :first_key_position,
         :key_step,
         :write?,
         :readonly?,
+        :request_policy,
+        :response_policy,
+        :subcommands,
         keyword_init: true
       ) do
         def extract_first_key(command)
@@ -86,31 +96,76 @@ class RedisClient
 
         private
 
-        def parse_command_reply(rows) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        def parse_command_reply(rows)
           rows&.each_with_object({}) do |row, acc|
             next if row.first.nil?
 
-            # TODO: in redis 7.0 or later, subcommand information included in the command reply
-
-            pos = case row.first
-                  when 'eval', 'evalsha', 'zinterstore', 'zunionstore' then 3
-                  when 'object', 'xgroup' then 2
-                  when 'migrate', 'xread', 'xreadgroup' then 0
-                  else row[3]
-                  end
-
-            writable = case row.first
-                       when 'xgroup' then true
-                       else row[2].include?('write')
-                       end
-
-            acc[row.first] = ::RedisClient::Cluster::Command::Spec.new(
-              first_key_position: pos,
-              key_step: row[5],
-              write?: writable,
-              readonly?: row[2].include?('readonly')
-            ).freeze
+            acc[row.first] = build_spec(row)
           end.freeze || EMPTY_HASH
+        end
+
+        def build_spec(row)
+          request_policy, response_policy = parse_tips(row[7])
+
+          ::RedisClient::Cluster::Command::Spec.new(
+            first_key_position: parse_first_key_position(row),
+            key_step: row[5],
+            write?: parse_writability(row),
+            readonly?: row[2].include?('readonly'),
+            request_policy: request_policy,
+            response_policy: response_policy,
+            subcommands: parse_subcommands(row[9])
+          ).freeze
+        end
+
+        # The redis 6.2 or earlier doesn't include the information of the subcommands in the reply.
+        # These hard-coded positions are the fallback for such old versions.
+        def parse_first_key_position(row)
+          case row.first
+          when 'eval', 'evalsha', 'zinterstore', 'zunionstore' then 3
+          when 'object', 'xgroup' then 2
+          when 'migrate', 'xread', 'xreadgroup' then 0
+          else row[3]
+          end
+        end
+
+        def parse_writability(row)
+          case row.first
+          when 'xgroup' then true
+          else row[2].include?('write')
+          end
+        end
+
+        # The command tips are available in the redis 7.0 or later.
+        def parse_tips(tips)
+          return EMPTY_POLICIES if tips.nil? || tips.empty?
+
+          request_policy = response_policy = nil
+
+          tips.each do |tip|
+            if tip.start_with?(REQUEST_POLICY_PREFIX)
+              request_policy = -tip[REQUEST_POLICY_PREFIX.size..]
+            elsif tip.start_with?(RESPONSE_POLICY_PREFIX)
+              response_policy = -tip[RESPONSE_POLICY_PREFIX.size..]
+            end
+          end
+
+          [request_policy, response_policy]
+        end
+
+        # The information of the subcommands is available in the redis 7.0 or later.
+        # A container command such as XINFO reports its key positions per subcommand.
+        def parse_subcommands(rows)
+          return if rows.nil? || rows.empty?
+
+          rows.each_with_object({}) do |row, acc|
+            name = row.first
+            next if name.nil?
+
+            # The server replies with a full name of the subcommand such as `xinfo|stream`.
+            i = name.index(SUBCOMMAND_DELIMITER)
+            acc[i.nil? ? name : name[(i + 1)..]] = build_spec(row)
+          end.freeze
         end
       end
 
@@ -118,8 +173,15 @@ class RedisClient
         @commands = commands || EMPTY_HASH
       end
 
-      def get_spec(name)
-        @commands[name] || @commands[name.to_s.downcase(:ascii)]
+      def get_spec(command) # rubocop:disable Metrics/AbcSize
+        name = command.first
+        spec = @commands[name] || @commands[name.to_s.downcase(:ascii)]
+        return spec if spec.nil? || spec.subcommands.nil?
+
+        subcommand = command[1]
+        return spec if subcommand.nil?
+
+        spec.subcommands[subcommand] || spec.subcommands[subcommand.to_s.downcase(:ascii)] || spec
       end
 
       def exists?(name)

--- a/lib/redis_client/cluster/node.rb
+++ b/lib/redis_client/cluster/node.rb
@@ -141,6 +141,16 @@ class RedisClient
         call_multiple_nodes!(@topology.replica_clients, method, command, args, &block)
       end
 
+      # for the `response_policy:one_succeeded` command tip
+      def call_all_leniently(method, command, args, &block)
+        call_multiple_nodes_leniently(@topology.clients, method, command, args, &block)
+      end
+
+      # for the `response_policy:one_succeeded` command tip
+      def call_primaries_leniently(method, command, args, &block)
+        call_multiple_nodes_leniently(@topology.primary_clients, method, command, args, &block)
+      end
+
       def send_ping(method, command, args, &block)
         result_values, errors = call_multiple_nodes(@topology.clients, method, command, args, &block)
         return result_values if errors.nil? || errors.empty?
@@ -261,6 +271,13 @@ class RedisClient
       def call_multiple_nodes!(clients, method, command, args, &block)
         result_values, errors = call_multiple_nodes(clients, method, command, args, &block)
         return result_values if errors.nil? || errors.empty?
+
+        raise ::RedisClient::Cluster::ErrorCollection.with_errors(errors)
+      end
+
+      def call_multiple_nodes_leniently(clients, method, command, args, &block)
+        result_values, errors = call_multiple_nodes(clients, method, command, args, &block)
+        return result_values unless result_values.nil? || result_values.empty?
 
         raise ::RedisClient::Cluster::ErrorCollection.with_errors(errors)
       end

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -17,30 +17,43 @@ class RedisClient
     class Router
       ZERO_CURSOR_FOR_SCAN = '0'
       TSF = ->(f, x) { f.nil? ? x : f.call(x) }.curry
+      RoutingAction = Struct.new('RedisCommandRoutingAction', :method_name, :reply_transformer, keyword_init: true)
+      PICK_FIRST = ->(reply) { reply.first } # rubocop:disable Style/SymbolProc
+      FLATTEN_STRINGS = ->(reply) { reply.flatten.sort_by(&:to_s) }
+      SUM_NUM = ->(reply) { reply.select { |e| e.is_a?(Integer) }.sum }
+      SORT_NUMBERS = ->(reply) { reply.sort_by(&:to_i) }
+      PICK_MIN = ->(reply) { reply.min } # rubocop:disable Style/SymbolProc
+      PICK_MAX = ->(reply) { reply.max } # rubocop:disable Style/SymbolProc
+      LOGICAL_AND = ->(reply) { reply.all? { |e| e != 0 } ? 1 : 0 }
+      LOGICAL_OR = ->(reply) { reply.any? { |e| e != 0 } ? 1 : 0 }
+      if Object.const_defined?(:Ractor, false) && Ractor.respond_to?(:make_shareable)
+        Ractor.make_shareable(PICK_FIRST)
+        Ractor.make_shareable(FLATTEN_STRINGS)
+        Ractor.make_shareable(SUM_NUM)
+        Ractor.make_shareable(SORT_NUMBERS)
+        Ractor.make_shareable(PICK_MIN)
+        Ractor.make_shareable(PICK_MAX)
+        Ractor.make_shareable(LOGICAL_AND)
+        Ractor.make_shareable(LOGICAL_OR)
+      end
       DEDICATED_ACTIONS = lambda do # rubocop:disable Metrics/BlockLength
-        action = Struct.new('RedisCommandRoutingAction', :method_name, :reply_transformer, keyword_init: true)
-        pick_first = ->(reply) { reply.first } # rubocop:disable Style/SymbolProc
-        flatten_strings = ->(reply) { reply.flatten.sort_by(&:to_s) }
-        sum_num = ->(reply) { reply.select { |e| e.is_a?(Integer) }.sum }
-        sort_numbers = ->(reply) { reply.sort_by(&:to_i) }
-        if Object.const_defined?(:Ractor, false) && Ractor.respond_to?(:make_shareable)
-          Ractor.make_shareable(pick_first)
-          Ractor.make_shareable(flatten_strings)
-          Ractor.make_shareable(sum_num)
-          Ractor.make_shareable(sort_numbers)
-        end
+        action = RoutingAction
         multiple_key_action = action.new(method_name: :send_multiple_keys_command)
-        all_node_first_action = action.new(method_name: :send_command_to_all_nodes, reply_transformer: pick_first)
-        primary_first_action = action.new(method_name: :send_command_to_primaries, reply_transformer: pick_first)
+        all_node_first_action = action.new(method_name: :send_command_to_all_nodes, reply_transformer: PICK_FIRST)
+        primary_first_action = action.new(method_name: :send_command_to_primaries, reply_transformer: PICK_FIRST)
         not_supported_action = action.new(method_name: :fail_not_supported_command)
         keyless_action = action.new(method_name: :fail_keyless_command)
+        # The redis 7.0 tags RANDOMKEY with `request_policy:all_shards` but without any response policy.
+        # It was corrected to `response_policy:special` in the redis 7.2.
+        # This entry keeps the historical single node routing for the redis 7.0.
+        default_action = action.new(method_name: :assign_node_and_send_command)
         {
-          'ping' => action.new(method_name: :send_ping_command, reply_transformer: pick_first),
+          'ping' => action.new(method_name: :send_ping_command, reply_transformer: PICK_FIRST),
           'wait' => action.new(method_name: :send_wait_command),
-          'keys' => action.new(method_name: :send_command_to_replicas, reply_transformer: flatten_strings),
-          'dbsize' => action.new(method_name: :send_command_to_replicas, reply_transformer: sum_num),
+          'keys' => action.new(method_name: :send_command_to_replicas, reply_transformer: FLATTEN_STRINGS),
+          'dbsize' => action.new(method_name: :send_command_to_replicas, reply_transformer: SUM_NUM),
           'scan' => action.new(method_name: :send_scan_command),
-          'lastsave' => action.new(method_name: :send_command_to_all_nodes, reply_transformer: sort_numbers),
+          'lastsave' => action.new(method_name: :send_command_to_all_nodes, reply_transformer: SORT_NUMBERS),
           'role' => action.new(method_name: :send_command_to_all_nodes),
           'config' => action.new(method_name: :send_config_command),
           'client' => action.new(method_name: :send_client_command),
@@ -61,6 +74,7 @@ class RedisClient
           'select' => all_node_first_action,
           'flushall' => primary_first_action,
           'flushdb' => primary_first_action,
+          'randomkey' => default_action,
           'readonly' => not_supported_action,
           'readwrite' => not_supported_action,
           'shutdown' => not_supported_action,
@@ -74,7 +88,38 @@ class RedisClient
         end
       end.call.freeze
 
-      private_constant :ZERO_CURSOR_FOR_SCAN, :TSF, :DEDICATED_ACTIONS
+      # The routing which the command tips of the COMMAND command reply instruct.
+      # The `multi_shard` and the `special` request policies are out of scope.
+      # The `special` response policy is also out of scope because the aggregation is undefined,
+      # and the fan-out would change the return value of commands such as INFO.
+      # The entries of the DEDICATED_ACTIONS take precedence over these to keep the existing behavior.
+      # @see https://redis.io/docs/latest/develop/reference/command-tips/
+      POLICY_ACTIONS = lambda do
+        transformers = {
+          nil => nil,
+          'all_succeeded' => PICK_FIRST,
+          'one_succeeded' => PICK_FIRST,
+          'agg_sum' => SUM_NUM,
+          'agg_min' => PICK_MIN,
+          'agg_max' => PICK_MAX,
+          'agg_logical_and' => LOGICAL_AND,
+          'agg_logical_or' => LOGICAL_OR
+        }.freeze
+
+        {
+          'all_shards' => %i[send_command_to_primaries send_command_to_primaries_leniently],
+          'all_nodes' => %i[send_command_to_all_nodes send_command_to_all_nodes_leniently]
+        }.each_with_object({}) do |(request_policy, (strictly, leniently)), acc|
+          acc[request_policy] = transformers.each_with_object({}) do |(response_policy, transformer), specified|
+            method_name = response_policy == 'one_succeeded' ? leniently : strictly
+            specified[response_policy] = RoutingAction.new(method_name: method_name, reply_transformer: transformer).freeze
+          end.freeze
+        end
+      end.call.freeze
+
+      private_constant :ZERO_CURSOR_FOR_SCAN, :TSF, :RoutingAction, :PICK_FIRST, :FLATTEN_STRINGS,
+                       :SUM_NUM, :SORT_NUMBERS, :PICK_MIN, :PICK_MAX, :LOGICAL_AND, :LOGICAL_OR,
+                       :DEDICATED_ACTIONS, :POLICY_ACTIONS
 
       attr_reader :config
 
@@ -94,7 +139,12 @@ class RedisClient
 
       def send_command(method, command, *args, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         action = DEDICATED_ACTIONS[command.first]
-        return assign_node_and_send_command(method, command, args, &block) if action.nil?
+        if action.nil?
+          cmd_spec = @command.get_spec(command)
+          action = find_policy_action(cmd_spec)
+          return assign_node_and_send_command(method, command, args, cmd_spec: cmd_spec, &block) if action.nil?
+        end
+
         return send(action.method_name, method, command, args, &block) if action.reply_transformer.nil?
 
         reply = send(action.method_name, method, command, args)
@@ -124,8 +174,8 @@ class RedisClient
       end
 
       # @see https://redis.io/docs/reference/cluster-spec/#redirection-and-resharding Redirection and resharding
-      def assign_node_and_send_command(method, command, args, retry_count: 3, &block)
-        node = assign_node(command)
+      def assign_node_and_send_command(method, command, args, retry_count: 3, cmd_spec: nil, &block)
+        node = assign_node(command, cmd_spec: cmd_spec)
         send_command_to_node(node, method, command, args, retry_count: retry_count, &block)
       end
 
@@ -218,9 +268,9 @@ class RedisClient
         end
       end
 
-      def assign_node(command)
+      def assign_node(command, cmd_spec: nil)
         handle_node_reload_error do
-          node_key = find_node_key(command)
+          node_key = find_node_key(command, cmd_spec: cmd_spec)
           @node.find_by(node_key)
         end
       end
@@ -246,8 +296,8 @@ class RedisClient
         end
       end
 
-      def find_node_key(command, seed: nil)
-        cmd_spec = @command.get_spec(command.first)
+      def find_node_key(command, seed: nil, cmd_spec: nil)
+        cmd_spec = @command.get_spec(command) if cmd_spec.nil?
         find_node_key_by_key(
           cmd_spec&.extract_first_key(command),
           seed: seed,
@@ -256,14 +306,14 @@ class RedisClient
       end
 
       def find_primary_node_key(command)
-        key = @command.get_spec(command.first)&.extract_first_key(command)
+        key = @command.get_spec(command)&.extract_first_key(command)
         return unless key&.size&.> 0
 
         find_node_key_by_key(key, primary: true)
       end
 
       def find_slot(command)
-        find_slot_by_key(@command.get_spec(command.first)&.extract_first_key(command))
+        find_slot_by_key(@command.get_spec(command)&.extract_first_key(command))
       end
 
       def find_slot_by_key(key)
@@ -308,12 +358,29 @@ class RedisClient
 
       private
 
+      def find_policy_action(cmd_spec)
+        return if cmd_spec.nil?
+
+        request_policy = cmd_spec.request_policy
+        return if request_policy.nil?
+
+        POLICY_ACTIONS.dig(request_policy, cmd_spec.response_policy)
+      end
+
       def send_command_to_all_nodes(method, command, args, &block)
         @node.call_all(method, command, args, &block)
       end
 
       def send_command_to_primaries(method, command, args, &block)
         @node.call_primaries(method, command, args, &block)
+      end
+
+      def send_command_to_all_nodes_leniently(method, command, args, &block)
+        @node.call_all_leniently(method, command, args, &block)
+      end
+
+      def send_command_to_primaries_leniently(method, command, args, &block)
+        @node.call_primaries_leniently(method, command, args, &block)
       end
 
       def send_command_to_replicas(method, command, args, &block)

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -89,24 +89,20 @@ class RedisClient
       # the single node routing until a command with a settled semantics appears.
       # The entries of the DEDICATED_ACTIONS take precedence over these to keep the existing behavior.
       # @see https://redis.io/docs/latest/develop/reference/command-tips/
-      POLICY_ACTIONS = lambda do
-        transformers = {
-          nil => nil,
-          'all_succeeded' => PICK_FIRST,
-          'one_succeeded' => PICK_FIRST,
-          'agg_sum' => SUM_NUM
+      POLICY_ACTIONS = {
+        'all_shards' => {
+          nil => RoutingAction.new(method_name: :send_command_to_primaries).freeze,
+          'all_succeeded' => RoutingAction.new(method_name: :send_command_to_primaries, reply_transformer: PICK_FIRST).freeze,
+          'one_succeeded' => RoutingAction.new(method_name: :send_command_to_primaries_leniently, reply_transformer: PICK_FIRST).freeze,
+          'agg_sum' => RoutingAction.new(method_name: :send_command_to_primaries, reply_transformer: SUM_NUM).freeze
+        }.freeze,
+        'all_nodes' => {
+          nil => RoutingAction.new(method_name: :send_command_to_all_nodes).freeze,
+          'all_succeeded' => RoutingAction.new(method_name: :send_command_to_all_nodes, reply_transformer: PICK_FIRST).freeze,
+          'one_succeeded' => RoutingAction.new(method_name: :send_command_to_all_nodes_leniently, reply_transformer: PICK_FIRST).freeze,
+          'agg_sum' => RoutingAction.new(method_name: :send_command_to_all_nodes, reply_transformer: SUM_NUM).freeze
         }.freeze
-
-        {
-          'all_shards' => %i[send_command_to_primaries send_command_to_primaries_leniently],
-          'all_nodes' => %i[send_command_to_all_nodes send_command_to_all_nodes_leniently]
-        }.each_with_object({}) do |(request_policy, (strictly, leniently)), acc|
-          acc[request_policy] = transformers.each_with_object({}) do |(response_policy, transformer), specified|
-            method_name = response_policy == 'one_succeeded' ? leniently : strictly
-            specified[response_policy] = RoutingAction.new(method_name: method_name, reply_transformer: transformer).freeze
-          end.freeze
-        end
-      end.call.freeze
+      }.freeze
 
       private_constant :ZERO_CURSOR_FOR_SCAN, :TSF, :RoutingAction, :PICK_FIRST, :FLATTEN_STRINGS,
                        :SUM_NUM, :SORT_NUMBERS, :DEDICATED_ACTIONS, :POLICY_ACTIONS

--- a/lib/redis_client/cluster/router.rb
+++ b/lib/redis_client/cluster/router.rb
@@ -22,46 +22,34 @@ class RedisClient
       FLATTEN_STRINGS = ->(reply) { reply.flatten.sort_by(&:to_s) }
       SUM_NUM = ->(reply) { reply.select { |e| e.is_a?(Integer) }.sum }
       SORT_NUMBERS = ->(reply) { reply.sort_by(&:to_i) }
-      PICK_MIN = ->(reply) { reply.min } # rubocop:disable Style/SymbolProc
-      PICK_MAX = ->(reply) { reply.max } # rubocop:disable Style/SymbolProc
-      LOGICAL_AND = ->(reply) { reply.all? { |e| e != 0 } ? 1 : 0 }
-      LOGICAL_OR = ->(reply) { reply.any? { |e| e != 0 } ? 1 : 0 }
       if Object.const_defined?(:Ractor, false) && Ractor.respond_to?(:make_shareable)
         Ractor.make_shareable(PICK_FIRST)
         Ractor.make_shareable(FLATTEN_STRINGS)
         Ractor.make_shareable(SUM_NUM)
         Ractor.make_shareable(SORT_NUMBERS)
-        Ractor.make_shareable(PICK_MIN)
-        Ractor.make_shareable(PICK_MAX)
-        Ractor.make_shareable(LOGICAL_AND)
-        Ractor.make_shareable(LOGICAL_OR)
       end
       DEDICATED_ACTIONS = lambda do # rubocop:disable Metrics/BlockLength
-        action = RoutingAction
-        multiple_key_action = action.new(method_name: :send_multiple_keys_command)
-        all_node_first_action = action.new(method_name: :send_command_to_all_nodes, reply_transformer: PICK_FIRST)
-        primary_first_action = action.new(method_name: :send_command_to_primaries, reply_transformer: PICK_FIRST)
-        not_supported_action = action.new(method_name: :fail_not_supported_command)
-        keyless_action = action.new(method_name: :fail_keyless_command)
-        # The redis 7.0 tags RANDOMKEY with `request_policy:all_shards` but without any response policy.
-        # It was corrected to `response_policy:special` in the redis 7.2.
-        # This entry keeps the historical single node routing for the redis 7.0.
-        default_action = action.new(method_name: :assign_node_and_send_command)
+        multiple_key_action = RoutingAction.new(method_name: :send_multiple_keys_command)
+        all_node_first_action = RoutingAction.new(method_name: :send_command_to_all_nodes, reply_transformer: PICK_FIRST)
+        primary_first_action = RoutingAction.new(method_name: :send_command_to_primaries, reply_transformer: PICK_FIRST)
+        not_supported_action = RoutingAction.new(method_name: :fail_not_supported_command)
+        keyless_action = RoutingAction.new(method_name: :fail_keyless_command)
+        single_node_action = RoutingAction.new(method_name: :assign_node_and_send_command)
         {
-          'ping' => action.new(method_name: :send_ping_command, reply_transformer: PICK_FIRST),
-          'wait' => action.new(method_name: :send_wait_command),
-          'keys' => action.new(method_name: :send_command_to_replicas, reply_transformer: FLATTEN_STRINGS),
-          'dbsize' => action.new(method_name: :send_command_to_replicas, reply_transformer: SUM_NUM),
-          'scan' => action.new(method_name: :send_scan_command),
-          'lastsave' => action.new(method_name: :send_command_to_all_nodes, reply_transformer: SORT_NUMBERS),
-          'role' => action.new(method_name: :send_command_to_all_nodes),
-          'config' => action.new(method_name: :send_config_command),
-          'client' => action.new(method_name: :send_client_command),
-          'cluster' => action.new(method_name: :send_cluster_command),
-          'memory' => action.new(method_name: :send_memory_command),
-          'script' => action.new(method_name: :send_script_command),
-          'pubsub' => action.new(method_name: :send_pubsub_command),
-          'watch' => action.new(method_name: :send_watch_command),
+          'ping' => RoutingAction.new(method_name: :send_ping_command, reply_transformer: PICK_FIRST),
+          'wait' => RoutingAction.new(method_name: :send_wait_command),
+          'keys' => RoutingAction.new(method_name: :send_command_to_replicas, reply_transformer: FLATTEN_STRINGS),
+          'dbsize' => RoutingAction.new(method_name: :send_command_to_replicas, reply_transformer: SUM_NUM),
+          'scan' => RoutingAction.new(method_name: :send_scan_command),
+          'lastsave' => RoutingAction.new(method_name: :send_command_to_all_nodes, reply_transformer: SORT_NUMBERS),
+          'role' => RoutingAction.new(method_name: :send_command_to_all_nodes),
+          'config' => RoutingAction.new(method_name: :send_config_command),
+          'client' => RoutingAction.new(method_name: :send_client_command),
+          'cluster' => RoutingAction.new(method_name: :send_cluster_command),
+          'memory' => RoutingAction.new(method_name: :send_memory_command),
+          'script' => RoutingAction.new(method_name: :send_script_command),
+          'pubsub' => RoutingAction.new(method_name: :send_pubsub_command),
+          'watch' => RoutingAction.new(method_name: :send_watch_command),
           'mget' => multiple_key_action,
           'mset' => multiple_key_action,
           'del' => multiple_key_action,
@@ -74,7 +62,10 @@ class RedisClient
           'select' => all_node_first_action,
           'flushall' => primary_first_action,
           'flushdb' => primary_first_action,
-          'randomkey' => default_action,
+          # The redis 7.0 tags RANDOMKEY with `request_policy:all_shards` but without any response policy.
+          # It was corrected to `response_policy:special` in the redis 7.2.
+          # This entry keeps the historical single node routing for the redis 7.0.
+          'randomkey' => single_node_action,
           'readonly' => not_supported_action,
           'readwrite' => not_supported_action,
           'shutdown' => not_supported_action,
@@ -92,6 +83,10 @@ class RedisClient
       # The `multi_shard` and the `special` request policies are out of scope.
       # The `special` response policy is also out of scope because the aggregation is undefined,
       # and the fan-out would change the return value of commands such as INFO.
+      # The `agg_min`, `agg_max` and `agg_logical_*` response policies are out of scope too:
+      # the only reachable command with them today is WAITAOF, whose reply is an array,
+      # and the aggregation of array replies is undefined. Such a command falls back to
+      # the single node routing until a command with a settled semantics appears.
       # The entries of the DEDICATED_ACTIONS take precedence over these to keep the existing behavior.
       # @see https://redis.io/docs/latest/develop/reference/command-tips/
       POLICY_ACTIONS = lambda do
@@ -99,11 +94,7 @@ class RedisClient
           nil => nil,
           'all_succeeded' => PICK_FIRST,
           'one_succeeded' => PICK_FIRST,
-          'agg_sum' => SUM_NUM,
-          'agg_min' => PICK_MIN,
-          'agg_max' => PICK_MAX,
-          'agg_logical_and' => LOGICAL_AND,
-          'agg_logical_or' => LOGICAL_OR
+          'agg_sum' => SUM_NUM
         }.freeze
 
         {
@@ -118,8 +109,7 @@ class RedisClient
       end.call.freeze
 
       private_constant :ZERO_CURSOR_FOR_SCAN, :TSF, :RoutingAction, :PICK_FIRST, :FLATTEN_STRINGS,
-                       :SUM_NUM, :SORT_NUMBERS, :PICK_MIN, :PICK_MAX, :LOGICAL_AND, :LOGICAL_OR,
-                       :DEDICATED_ACTIONS, :POLICY_ACTIONS
+                       :SUM_NUM, :SORT_NUMBERS, :DEDICATED_ACTIONS, :POLICY_ACTIONS
 
       attr_reader :config
 

--- a/test/redis_client/cluster/test_command.rb
+++ b/test/redis_client/cluster/test_command.rb
@@ -74,8 +74,94 @@ class RedisClient
               ['set', -3, Set['write', 'denyoom', 'movablekeys'], 1, -1, 2, Set['@write', '@string', '@slow'], Set[], Set[], Set[]]
             ],
             want: {
-              'get' => { first_key_position: 1, key_step: 1, write?: false, readonly?: true },
-              'set' => { first_key_position: 1, key_step: 2, write?: true, readonly?: false }
+              'get' => {
+                first_key_position: 1, key_step: 1, write?: false, readonly?: true,
+                request_policy: nil, response_policy: nil, subcommands: nil
+              },
+              'set' => {
+                first_key_position: 1, key_step: 2, write?: true, readonly?: false,
+                request_policy: nil, response_policy: nil, subcommands: nil
+              }
+            }
+          },
+          {
+            # a container command of the redis 7.0 or later
+            rows: [
+              [
+                'xinfo', -2, Set[], 0, 0, 0, Set['@slow'], Set[], Set[],
+                [
+                  ['xinfo|stream', -3, Set['readonly'], 2, 2, 1, Set['@read', '@stream', '@slow'], Set[], Set[], Set[]],
+                  ['xinfo|help', 2, Set['loading', 'stale'], 0, 0, 0, Set['@stream', '@slow'], Set[], Set[], Set[]]
+                ]
+              ]
+            ],
+            want: {
+              'xinfo' => {
+                first_key_position: 0, key_step: 0, write?: false, readonly?: false,
+                request_policy: nil, response_policy: nil,
+                subcommands: {
+                  'stream' => {
+                    first_key_position: 2, key_step: 1, write?: false, readonly?: true,
+                    request_policy: nil, response_policy: nil, subcommands: nil
+                  },
+                  'help' => {
+                    first_key_position: 0, key_step: 0, write?: false, readonly?: false,
+                    request_policy: nil, response_policy: nil, subcommands: nil
+                  }
+                }
+              }
+            }
+          },
+          {
+            # command tips of the redis 7.0 or later
+            rows: [
+              [
+                'function', -2, Set[], 0, 0, 0, Set['@slow'], Set[], Set[],
+                [
+                  [
+                    'function|load', -3, Set['write', 'denyoom', 'noscript'], 0, 0, 0, Set['@write', '@slow', '@scripting'],
+                    Set['request_policy:all_shards', 'response_policy:all_succeeded'], Set[], Set[]
+                  ]
+                ]
+              ],
+              ['dbsize', 1, Set['readonly', 'fast'], 0, 0, 0, Set['@keyspace', '@read', '@fast'],
+               Set['request_policy:all_shards', 'response_policy:agg_sum'], Set[], Set[]]
+            ],
+            want: {
+              'function' => {
+                first_key_position: 0, key_step: 0, write?: false, readonly?: false,
+                request_policy: nil, response_policy: nil,
+                subcommands: {
+                  'load' => {
+                    first_key_position: 0, key_step: 0, write?: true, readonly?: false,
+                    request_policy: 'all_shards', response_policy: 'all_succeeded', subcommands: nil
+                  }
+                }
+              },
+              'dbsize' => {
+                first_key_position: 0, key_step: 0, write?: false, readonly?: true,
+                request_policy: 'all_shards', response_policy: 'agg_sum', subcommands: nil
+              }
+            }
+          },
+          {
+            # the reply of the redis 6.x doesn't have the tips and the subcommands
+            rows: [['object', -2, Set['readonly'], 0, 0, 0, Set['@keyspace', '@read', '@slow']]],
+            want: {
+              'object' => {
+                first_key_position: 2, key_step: 0, write?: false, readonly?: true,
+                request_policy: nil, response_policy: nil, subcommands: nil
+              }
+            }
+          },
+          {
+            # the reply of the redis 5.x doesn't have the ACL categories either
+            rows: [['xgroup', -2, %w[write denyoom], 0, 0, 0]],
+            want: {
+              'xgroup' => {
+                first_key_position: 2, key_step: 0, write?: true, readonly?: false,
+                request_policy: nil, response_policy: nil, subcommands: nil
+              }
             }
           },
           { rows: [[]], want: {} },
@@ -87,8 +173,32 @@ class RedisClient
           assert_equal(c[:want].size, got.size, msg)
           assert_equal(c[:want].keys.sort, got.keys.sort, msg)
           c[:want].each do |k, v|
-            assert_equal(v, got[k].to_h, "#{msg}: #{k}")
+            assert_equal(v, to_nested_hash(got[k]), "#{msg}: #{k}")
           end
+        end
+      end
+
+      def test_get_spec_with_subcommands
+        rows = [
+          ['get', 2, Set['readonly', 'fast'], 1, -1, 1, Set[], Set[], Set[], Set[]],
+          [
+            'xinfo', -2, Set[], 0, 0, 0, Set[], Set[], Set[],
+            [['xinfo|stream', -3, Set['readonly'], 2, 2, 1, Set[], Set[], Set[], Set[]]]
+          ]
+        ]
+        cmd = ::RedisClient::Cluster::Command.new(::RedisClient::Cluster::Command.send(:parse_command_reply, rows))
+        [
+          { command: %w[xinfo stream mystream], want: 2 },
+          { command: %w[XINFO STREAM mystream], want: 2 },
+          { command: %w[xinfo groups mystream], want: 0 }, # an unknown subcommand falls back to the container
+          { command: %w[xinfo], want: 0 },
+          { command: %w[get foo], want: 1 },
+          { command: %w[unknown foo], want: nil },
+          { command: [], want: nil }
+        ].each_with_index do |c, idx|
+          msg = "Case: #{idx}"
+          got = cmd.get_spec(c[:command])&.first_key_position
+          c[:want].nil? ? assert_nil(got, msg) : assert_equal(c[:want], got, msg)
         end
       end
 
@@ -107,14 +217,23 @@ class RedisClient
           { command: %w[zinterstore out 2 zset1 zset2 weights 2 3], want: 'zset1' },
           { command: %w[zunionstore out 2 zset1 zset2 weights 2 3], want: 'zset1' },
           { command: %w[object encoding key], want: 'key' },
+          { command: %w[OBJECT ENCODING key], want: 'key' },
           { command: %w[memory help], want: '' },
           { command: %w[memory usage key], want: 'key' },
+          { command: %w[xgroup create key group $], want: 'key' },
           { command: %w[xread count 2 streams mystream writers 0-0 0-0], want: 'mystream' },
           { command: %w[xreadgroup group group consumer streams key id], want: 'key' },
-          { command: %w[unknown foo bar], want: nil }
+          { command: %w[unknown foo bar], want: nil },
+          # The key positions of the subcommands are available in the redis 7.0 or later.
+          { command: %w[xinfo stream key], want: 'key', supported_redis_version: 7 },
+          { command: %w[XINFO STREAM key], want: 'key', supported_redis_version: 7 },
+          { command: %w[xinfo help], want: '', supported_redis_version: 7 },
+          { command: %w[client no-evict on], want: '', supported_redis_version: 7 }
         ].each_with_index do |c, idx|
+          next if c.key?(:supported_redis_version) && c[:supported_redis_version] > TEST_REDIS_MAJOR_VERSION
+
           msg = "Case: #{idx}"
-          got = cmd.get_spec(c[:command].first)&.extract_first_key(c[:command])
+          got = cmd.get_spec(c[:command])&.extract_first_key(c[:command])
           if c[:want].nil?
             assert_nil(got, msg)
           else
@@ -130,11 +249,15 @@ class RedisClient
           { command: %w[SET foo 1], want: true },
           { command: %w[get foo], want: false },
           { command: %w[GET foo], want: false },
+          { command: %w[xgroup create key group $], want: true },
           { command: %w[unknown foo bar], want: nil },
-          { command: [], want: nil }
+          { command: [], want: nil },
+          { command: %w[xinfo stream key], want: false, supported_redis_version: 7 }
         ].each_with_index do |c, idx|
+          next if c.key?(:supported_redis_version) && c[:supported_redis_version] > TEST_REDIS_MAJOR_VERSION
+
           msg = "Case: #{idx}"
-          got = cmd.get_spec(c[:command].first)&.should_send_to_primary?
+          got = cmd.get_spec(c[:command])&.should_send_to_primary?
           c[:want].nil? ? assert_nil(got, msg) : assert_equal(c[:want], got, msg)
         end
       end
@@ -147,11 +270,36 @@ class RedisClient
           { command: %w[get foo], want: true },
           { command: %w[GET foo], want: true },
           { command: %w[unknown foo bar], want: nil },
-          { command: [], want: nil }
+          { command: [], want: nil },
+          { command: %w[xinfo stream key], want: true, supported_redis_version: 7 }
+        ].each_with_index do |c, idx|
+          next if c.key?(:supported_redis_version) && c[:supported_redis_version] > TEST_REDIS_MAJOR_VERSION
+
+          msg = "Case: #{idx}"
+          got = cmd.get_spec(c[:command])&.should_send_to_replica?
+          c[:want].nil? ? assert_nil(got, msg) : assert_equal(c[:want], got, msg)
+        end
+      end
+
+      def test_command_tips
+        skip('The command tips are available in the redis 7.0 or later.') if TEST_REDIS_MAJOR_VERSION < 7
+
+        cmd = ::RedisClient::Cluster::Command.load(@raw_clients)
+        [
+          { command: %w[get foo], request_policy: nil, response_policy: nil },
+          { command: %w[dbsize], request_policy: 'all_shards', response_policy: 'agg_sum' },
+          { command: %w[function load lib], request_policy: 'all_shards', response_policy: 'all_succeeded' },
+          { command: %w[function kill], request_policy: 'all_shards', response_policy: 'one_succeeded' },
+          { command: %w[info], request_policy: 'all_shards', response_policy: 'special' },
+          { command: %w[mget foo bar], request_policy: 'multi_shard', response_policy: nil }
         ].each_with_index do |c, idx|
           msg = "Case: #{idx}"
-          got = cmd.get_spec(c[:command].first)&.should_send_to_replica?
-          c[:want].nil? ? assert_nil(got, msg) : assert_equal(c[:want], got, msg)
+          spec = cmd.get_spec(c[:command])
+
+          refute_nil(spec, msg)
+          assert_equal({ request_policy: c[:request_policy], response_policy: c[:response_policy] },
+                       { request_policy: spec.request_policy, response_policy: spec.response_policy },
+                       msg)
         end
       end
 
@@ -171,6 +319,14 @@ class RedisClient
           msg = "Case: #{idx}"
           got = cmd.exists?(c[:name])
           assert_equal(c[:want], got, msg)
+        end
+      end
+
+      private
+
+      def to_nested_hash(spec)
+        spec.to_h.tap do |h|
+          h[:subcommands] = h[:subcommands]&.transform_values { |sub| to_nested_hash(sub) }
         end
       end
     end

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -750,6 +750,64 @@ class RedisClient
         assert_equal('data2', got2.fetch('{stream}1')[0][1][1])
       end
 
+      def test_container_command_routing
+        skip('The key specs of the subcommands are available in the redis 7.0 or later.') if TEST_REDIS_MAJOR_VERSION < 7
+
+        @client.call('xadd', 'mystream', '*', 'message', 'foo')
+        wait_for_replication
+        @captured_commands.clear
+
+        # The router should be able to resolve the key of a container command.
+        router = @client.instance_variable_get(:@router)
+
+        refute_nil(router.find_primary_node_key(%w[XINFO STREAM mystream]))
+
+        got = @client.call('XINFO', 'STREAM', 'mystream')
+        got = got.each_slice(2).to_h if got.is_a?(Array)
+
+        assert_equal(1, got.fetch('length'))
+        assert_equal(1, @captured_commands.count('xinfo', 'stream'))
+
+        # A container command should be able to pin the node of a transaction.
+        got = @client.multi { |tx| tx.call('XINFO', 'STREAM', 'mystream') }.first
+        got = got.each_slice(2).to_h if got.is_a?(Array)
+
+        assert_equal(1, got.fetch('length'))
+      end
+
+      def test_command_tips_request_policy
+        skip('The command tips are available in the redis 7.0 or later.') if TEST_REDIS_MAJOR_VERSION < 7
+
+        lua = "#!lua name=mylib\nredis.register_function('myfunc', function(keys, args) return 1 end)"
+        @captured_commands.clear
+
+        # FUNCTION LOAD is tagged with `request_policy:all_shards` and `response_policy:all_succeeded`.
+        assert_equal('mylib', @client.call('FUNCTION', 'LOAD', 'REPLACE', lua))
+
+        loaded = @captured_commands.to_a.select { |e| e.command.first.casecmp('function').zero? }
+
+        assert_equal(TEST_SHARD_SIZE, loaded.size)
+        assert_equal(TEST_SHARD_SIZE, loaded.map(&:server_url).uniq.size)
+
+        # The library should be available on every shard.
+        assert_equal(TEST_SHARD_SIZE, count_primaries_having_functions)
+      ensure
+        @client&.call('FUNCTION', 'FLUSH') if TEST_REDIS_MAJOR_VERSION >= 7
+      end
+
+      def test_command_tips_special_response_policy_is_ignored
+        # The commands with `response_policy:special` are sent to a single node as before
+        # because the aggregation of the replies is undefined.
+        @captured_commands.clear
+
+        assert_instance_of(String, @client.call('INFO'))
+        assert_equal(1, @captured_commands.count('info'))
+
+        @captured_commands.clear
+        refute_instance_of(Array, @client.call('RANDOMKEY'))
+        assert_equal(1, @captured_commands.count('randomkey'))
+      end
+
       def test_dedicated_multiple_keys_command
         [
           { command: %w[MSET key1 val1], want: 'OK', wait: true },
@@ -933,6 +991,17 @@ class RedisClient
       end
 
       private
+
+      def count_primaries_having_functions
+        TEST_NODE_URIS.count do |uri|
+          raw = ::RedisClient.config(url: uri, **TEST_GENERIC_OPTIONS).new_client
+          begin
+            raw.call('INFO', 'replication').include?('role:master') && !raw.call('FUNCTION', 'LIST').empty?
+          ensure
+            raw.close
+          end
+        end
+      end
 
       def wait_for_replication
         client_side_timeout = TEST_TIMEOUT_SEC + 1.0


### PR DESCRIPTION
## Summary

Since the redis 7.0, the reply of the `COMMAND` command carries the key specs of each subcommand (the 10th element) and the [command tips](https://redis.io/docs/latest/develop/reference/command-tips/) (the 8th element), but this gem read only the flags, the first key position and the key step of each top level command and approximated the rest with the hard-coded tables. This PR makes the router follow what the server reports, so that newly added commands are routed correctly without a new release of this gem.

* A container command such as `XINFO STREAM key` couldn't extract its key, so it was sent to an arbitrary node and it couldn't pin the node of a transaction. (#532)
* A command with the `request_policy` tip such as `FUNCTION LOAD` was sent to a single node although it should be sent to every shard. (#534)

The redis 6.2 or earlier doesn't report them, so the hard-coded tables are kept as the fallback. They also take precedence over the tips to keep the existing behavior.

## Changes

### `Command`

* `Spec` holds `request_policy`, `response_policy` and `subcommands` in addition to the existing members.
* `parse_command_reply` builds a spec per subcommand from the 10th element of each row. The spec of a subcommand is looked up by `get_spec` which now takes a whole command instead of a command name. The lookup of a subcommand happens only when the parent command is a container command, so the resolution of a plain command costs the same as before.
* The command tips of the 8th element are parsed into the request policy and the response policy.
* The existing hard-coded positions (`eval`, `object`, `xgroup`, `migrate` and so on) and the ones in `Spec#determine_first_key_position` are kept for the older servers.

### `Router`

* When a command has no `DEDICATED_ACTIONS` entry, the request policy of its spec decides the routing:
  * `all_shards` -> `send_command_to_primaries`
  * `all_nodes` -> `send_command_to_all_nodes`
* The response policy decides the aggregation: `all_succeeded`, `one_succeeded` and `agg_sum`. Without a response policy, the replies of the nodes are returned as an array as the other fan-out commands of this gem do.
* `one_succeeded` needs to tolerate the errors of a part of the nodes, so `Node#call_primaries_leniently` and `Node#call_all_leniently` were added. They raise an `ErrorCollection` only when every node fails.

### Out of scope

* The `multi_shard` and the `special` request policies. `MGET`, `MSET` and `DEL` are still handled by `send_multiple_keys_command`, and `EXISTS`, `TOUCH` and `UNLINK` are still sent to the node of their first key.
* The `special` response policy. The aggregation is undefined and the fan-out would change the return value of the commands such as `INFO` and `RANDOMKEY`. They are sent to a single node as before.
* The `agg_min`, `agg_max` and `agg_logical_*` response policies. The only reachable command with them today is `WAITAOF`, whose reply is an array of `[numlocal, numreplicas]`, and the aggregation of array replies is undefined (`Array#min` compares lexicographically, which could return a reply which guarantees nothing as the cluster-wide minimum). Such a command is sent to a single node as before, until a command with a settled semantics appears.
* The tier 2 of #534, which is the public API such as `call_on_all_primaries`. This gem keeps the compatibility of the public API with redis-client, so it isn't added.

### Commands whose routing changes

`FUNCTION DELETE|FLUSH|KILL|LOAD|RESTORE`, `SLOWLOG GET|LEN|RESET`, `LATENCY RESET` and the `HIMPORT PREPARE|DISCARD|DISCARDALL` family of the redis 8.10. The commands in `DEDICATED_ACTIONS` are not affected at all.

`RANDOMKEY` got a `DEDICATED_ACTIONS` entry which pins the historical single node routing, because only the redis 7.0 tags it with `request_policy:all_shards` without any response policy. It was corrected to `response_policy:special` in the redis 7.2.

## Testing

* `bundle exec rake test` passes against the redis 8, 7.4, 6.2, 5.0 and the valkey 9.1. The new test cases which need the redis 7.0 or later are skipped on the older servers, so the fallback path is covered too.
* `bundle exec rake test_cluster_down` passes against the redis 8.
* `bundle exec rubocop` reports no offense.
* `bundle exec rake prof test/prof_mem.rb` reports the same number of the allocated objects per command as before. The spec of the router is looked up once per command as before because it's passed down to `#assign_node_and_send_command`. The catalog of the commands allocates about 1,300 more objects when a client loads it, which is the cost of the specs of about 200 subcommands.
