### PR TITLE
refactor: avoid the allocation of the range objects on the string slicing

### DIFF
--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -144,9 +144,9 @@ class RedisClient
 
           tips.each do |tip|
             if tip.start_with?(REQUEST_POLICY_PREFIX)
-              request_policy = -tip[REQUEST_POLICY_PREFIX.size..]
+              request_policy = -tip.delete_prefix(REQUEST_POLICY_PREFIX)
             elsif tip.start_with?(RESPONSE_POLICY_PREFIX)
-              response_policy = -tip[RESPONSE_POLICY_PREFIX.size..]
+              response_policy = -tip.delete_prefix(RESPONSE_POLICY_PREFIX)
             end
           end
 
@@ -164,7 +164,7 @@ class RedisClient
 
             # The server replies with a full name of the subcommand such as `xinfo|stream`.
             i = name.index(SUBCOMMAND_DELIMITER)
-            acc[i.nil? ? name : name[(i + 1)..]] = build_spec(row)
+            acc[i.nil? ? name : name[i + 1, name.size]] = build_spec(row)
           end.freeze
         end
       end

--- a/lib/redis_client/cluster/node_key.rb
+++ b/lib/redis_client/cluster/node_key.rb
@@ -26,7 +26,7 @@ class RedisClient
         pos = node_key.rindex(DELIMITER, -1)
         return [node_key, nil] if pos.nil?
 
-        [node_key[0, pos], node_key[(pos + 1)..]]
+        [node_key[0, pos], node_key[pos + 1, node_key.size]]
       end
 
       def split_bracketed(node_key)
@@ -36,7 +36,7 @@ class RedisClient
         return nil if end_bracket.nil?
 
         host = node_key[1, end_bracket - 1]
-        remainder = node_key[(end_bracket + 1)..]
+        remainder = node_key[end_bracket + 1, node_key.size]
         port = remainder.start_with?(DELIMITER) ? remainder[1..] : nil
         [host, port]
       end


### PR DESCRIPTION
## Summary

A follow-up of #535. Some string slicings use a range whose boundary is an expression, such as `tip[REQUEST_POLICY_PREFIX.size..]`. Unlike a range literal such as `str[1..]`, which the compiler caches as a frozen object (`putobject 1..`), a range with a computed boundary is built by the `newrange` instruction and allocates a range object on every call.

This PR replaces them with `String#delete_prefix` (for stripping the policy prefixes of the command tips) and the index and length form (for the slicings after a delimiter). The range literals such as `command[1..]` are left as is because they don't allocate.

## Measurement

Allocated objects of a single `Command.load` against a 3 shard cluster (ruby 4.0.5):

| | objects |
| --- | --- |
| master | 21,491 |
| this PR | 21,187 (-304) |

The eliminated allocations are the range objects of the tips parsing (about 100) and the subcommand name parsing (about 200), which happen once per the initialization of a client. The per-command hot path doesn't use these code paths.

## Correctness

All the call sites behave the same as before including the edge cases: a trailing delimiter (`"host:"` -> `["host", ""]`), an empty subcommand name (`"xinfo|"` -> `""`) and the bracketed IPv6 node keys. The whole test suite passes against the redis 8.

Note that `String#[]` with the index and length form needs a length, so the receiver's own size is passed to mean "to the end". `String#delete_prefix` is available since the ruby 2.5, which satisfies the required ruby version 2.7 of this gem.
