### PR TITLE
refactor: avoid the allocation of the array by the multiple return values

### DIFF
--- a/lib/redis_client/cluster/command.rb
+++ b/lib/redis_client/cluster/command.rb
@@ -9,12 +9,11 @@ class RedisClient
     class Command
       EMPTY_STRING = ''
       EMPTY_HASH = {}.freeze
-      EMPTY_POLICIES = [nil, nil].freeze
       REQUEST_POLICY_PREFIX = 'request_policy:'
       RESPONSE_POLICY_PREFIX = 'response_policy:'
       SUBCOMMAND_DELIMITER = '|'
 
-      private_constant :EMPTY_HASH, :EMPTY_POLICIES, :REQUEST_POLICY_PREFIX,
+      private_constant :EMPTY_HASH, :REQUEST_POLICY_PREFIX,
                        :RESPONSE_POLICY_PREFIX, :SUBCOMMAND_DELIMITER
 
       # @see https://redis.io/docs/latest/commands/command/ The reply of the COMMAND command
@@ -105,15 +104,13 @@ class RedisClient
         end
 
         def build_spec(row)
-          request_policy, response_policy = parse_tips(row[7])
-
           ::RedisClient::Cluster::Command::Spec.new(
             first_key_position: parse_first_key_position(row),
             key_step: row[5],
             write?: parse_writability(row),
             readonly?: row[2].include?('readonly'),
-            request_policy: request_policy,
-            response_policy: response_policy,
+            request_policy: parse_policy_tip(row[7], REQUEST_POLICY_PREFIX),
+            response_policy: parse_policy_tip(row[7], RESPONSE_POLICY_PREFIX),
             subcommands: parse_subcommands(row[9])
           ).freeze
         end
@@ -137,20 +134,10 @@ class RedisClient
         end
 
         # The command tips are available in the redis 7.0 or later.
-        def parse_tips(tips)
-          return EMPTY_POLICIES if tips.nil? || tips.empty?
-
-          request_policy = response_policy = nil
-
-          tips.each do |tip|
-            if tip.start_with?(REQUEST_POLICY_PREFIX)
-              request_policy = -tip.delete_prefix(REQUEST_POLICY_PREFIX)
-            elsif tip.start_with?(RESPONSE_POLICY_PREFIX)
-              response_policy = -tip.delete_prefix(RESPONSE_POLICY_PREFIX)
-            end
-          end
-
-          [request_policy, response_policy]
+        # It returns a single value instead of a pair to avoid the allocation of the array.
+        def parse_policy_tip(tips, prefix)
+          tip = tips&.find { |t| t.start_with?(prefix) }
+          tip.nil? ? nil : -tip.delete_prefix(prefix)
         end
 
         # The information of the subcommands is available in the redis 7.0 or later.


### PR DESCRIPTION
## Summary

A follow-up of #535 and #537. `parse_tips` returned a pair of the policies, and the multiple return values allocate an array per call in ruby, unlike the languages such as go. The array was allocated for every command which has the command tips.

The parser is now `parse_policy_tip(tips, prefix)`, which takes a policy prefix and returns a single value, and `build_spec` calls it once per policy. The `EMPTY_POLICIES` constant which existed to make the early return allocation-free isn't needed anymore.

The tips are scanned twice instead of once, but a tips array has a few elements at most and the parsing happens only on the loading of the command catalog. Most commands have no tips, in which case `find` through the safe navigation returns nil immediately.

Note that a literal block passed to `Enumerable#find` isn't reified into a proc object, so there is no hidden allocation there.

## Measurement

Allocated objects of a single `Command.load` against a 3 shard cluster (ruby 4.0.5):

| | objects |
| --- | --- |
| master | 21,189 |
| this PR | 21,082 (-107) |

The reduction matches the number of the rows which have at least one policy tip. The return values are identical to the previous implementation for all the cases: tips present, empty and nil.

## Testing

The whole test suite passes against the redis 8 and rubocop reports no offense.
