### PR TITLE
docs: state the policy of the public API in the interfaces section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ The `#multi` method supports the transaction feature but you should use a hashta
 The `#pubsub` method supports sharded subscriptions.
 Every interface handles redirections and resharding states internally.
 
+This gem is aimed to keep the compatibility with the public API of [redis-client](https://github.com/redis-rb/redis-client).
+Hence, there is no plan to add its own public methods beyond the above for the time being.
+
 ## Command routing
 This gem calls the [COMMAND](https://redis.io/commands/command) command on startup and decides
 which node each command should be sent to according to the reply.


### PR DESCRIPTION
## Summary

This PR adds a short note at the end of the interfaces section of the README: this gem is aimed to keep the compatibility with the public API of [redis-client](https://github.com/redis-rb/redis-client), and there is no plan to add its own public methods beyond the existing ones for the time being.

This policy was the reason not to implement the tier 2 proposal of #534, which requested the public routing primitives such as `call_on_all_primaries`. Documenting it lets the contributors know the policy before designing a feature which needs a new interface, and gives the maintainer a reference to point to when such a request comes up.
