### PR TITLE
test: wait for replicas to be recognized as online before running tests

### DIFF
--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -66,6 +66,8 @@ class ClusterController
     wait_cluster_building(@clients, max_attempts: @max_attempts)
     print_debug('wait for the replication to be established...')
     wait_replication(@clients, number_of_replicas: @number_of_replicas, max_attempts: @max_attempts)
+    print_debug('wait for the replicas to be recognized as online...')
+    wait_replication_health(@clients, max_attempts: @max_attempts)
     print_debug('wait for commands to be accepted...')
     wait_cluster_recovering(@clients, max_attempts: @max_attempts, skip_clients: skip_clients)
   end
@@ -81,6 +83,7 @@ class ClusterController
     save_config(@clients)
     wait_cluster_building(@clients, max_attempts: @max_attempts)
     wait_replication(@clients, number_of_replicas: @number_of_replicas, max_attempts: @max_attempts)
+    wait_replication_health(@clients, max_attempts: @max_attempts)
     wait_cluster_recovering(@clients, max_attempts: @max_attempts)
   end
 
@@ -382,6 +385,33 @@ class ClusterController
       rows.count(&:replica?) == number_of_replicas
     rescue ::RedisClient::ConnectionError
       true
+    end
+  end
+
+  # The client library trusts the health field of the CLUSTER SHARDS reply and excludes non-online nodes
+  # from the topology. Right after a cluster is built, replicas are reported as loading until the queried
+  # node learns their replication offsets via gossip, and each node converges at a different time.
+  # Tests expecting replicas flake unless we wait for every node's view to be settled.
+  def wait_replication_health(clients, max_attempts:)
+    wait_for_state(clients, max_attempts: max_attempts) do |client|
+      healths = fetch_cluster_shard_node_healths(client)
+      print_debug("#{client.config.host}:#{client.config.port} ... #{healths.tally}")
+      healths.none? { |health| health == 'loading' }
+    rescue ::RedisClient::CommandError => e
+      raise unless e.message.start_with?('ERR Unknown subcommand')
+
+      true
+    rescue ::RedisClient::ConnectionError
+      true
+    end
+  end
+
+  def fetch_cluster_shard_node_healths(client)
+    client.call_once('CLUSTER', 'SHARDS').flat_map do |shard|
+      shard = shard.each_slice(2).to_h if shard.is_a?(Array)
+      nodes = shard.fetch('nodes')
+      nodes = nodes.map { |node| node.each_slice(2).to_h } unless nodes.first.is_a?(Hash)
+      nodes.map { |node| node.fetch('health') }
     end
   end
 


### PR DESCRIPTION
Fix #541

## Root cause

The flaky failures in the valkey jobs are caused by a race between the readiness check of `rake wait` and the `health` field of the `CLUSTER SHARDS` reply:

1. Right after a cluster is built, `CLUSTER SHARDS` reports each replica as `health=loading` (`replication-offset` is `0`) until the queried node learns the replica's offset via gossip. Measured locally, this window lasts around 10 seconds after the replication is configured, and each node's view converges at a different time.
2. The client library excludes non-online nodes from the topology (`parse_cluster_shards_reply`), so a `RedisClient::Cluster::Node` built inside this window sees a primary-only topology, and two instances built moments apart can see different topologies. This reproduces all the reported failures:
   - `TestRandomReplicaWithPrimary#test_clients_*`: got `["master"]` because all replicas were filtered out
   - `TestRandomReplicaWithPrimary#test_any_replica_node_key`: `@replications` had no replicas so `any_replica_node_key` fell back to a primary node key
   - `TestNode#test_find_by`: the two test nodes fetched divergent views, so the scale-read node raised `ReloadNeeded` for a node key the other node knew
3. `wait_for_cluster_to_be_ready` checked the replication state only through `CLUSTER NODES` flags, which report replicas as `slave`/`connected` at the start of the window, so `rake wait` could finish while replicas were still `loading`.
4. Since minitest 6 randomizes the test class run order (cf. #456), the replica-dependent test classes occasionally run at the very beginning of the suite. In the failing CI run, `TestRandomReplicaWithPrimary` ran within the first 100ms after `rake wait` passed.

This isn't Valkey-specific: the same loading window was measured locally with `redis:8` on `compose.replica.yaml`. The valkey jobs are just the most exposed because two of them run with `replica: 2` every day. PR #533 isn't related either; the `health != 'online'` filter has existed since #479.

## Fix

Add a step to `ClusterController#wait_for_cluster_to_be_ready` and `#rebuild` that waits until no node's `CLUSTER SHARDS` view contains a `loading` node.

- A killed node is reported as `fail`, not `loading`, so the paths used by the broken-cluster tests don't block on dead nodes (verified locally: `{"online" => 8, "fail" => 1}` passes through).
- Servers without `CLUSTER SHARDS` skip the check.

## Verification

With a freshly created valkey 9 cluster (`compose.valkey.yaml`, `REDIS_REPLICA_SIZE=2`), `rake wait` now blocks through the window and releases only after every node reports all 9 nodes online:

```
"wait for the replicas to be recognized as online..."
"127.0.0.1:6379 ... {\"online\" => 3, \"loading\" => 6}"   # <- the old code would have started the tests here
...
"127.0.0.1:6379 ... {\"online\" => 9}"
"127.0.0.1:6380 ... {\"online\" => 9}"
```

`test/redis_client/cluster/node/test_random_replica_or_primary.rb` and `test/redis_client/cluster/test_node.rb` pass right after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)