### PR TITLE
test: restore the read timeout even if the swapped block raises an error

### DIFF
--- a/test/cluster_controller.rb
+++ b/test/cluster_controller.rb
@@ -556,8 +556,8 @@ class ClusterController
 
     regular_timeout = client.read_timeout
     updater.call(client, timeout)
-    result = yield client
+    yield client
+  ensure
     updater.call(client, regular_timeout)
-    result
   end
 end

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -32,8 +32,8 @@ class TestingWrapper < Minitest::Test
 
     regular_timeout = node.first.read_timeout
     node.each { |cli| updater.call(cli, timeout) }
-    result = yield client
-    node.each { |cli| updater.call(cli, regular_timeout) }
-    result
+    yield client
+  ensure
+    node&.each { |cli| updater.call(cli, regular_timeout) }
   end
 end


### PR DESCRIPTION
## Problem

The scheduled builds have been flaky. 20 of the last 100 `Test` runs failed, and every failure whose log is still retained shows the same signature:

```
RedisClient::ReadTimeoutError: Waited 0.1 seconds
```

The failing point differs per job, but it is always the first `call_once` issued after `ClusterController#wait_replication_delay`:

| Run | Job | Failing call |
| --- | --- | --- |
| [31973306492](https://github.com/redis-rb/redis-cluster-client/actions/runs/31973306492), [31939179365](https://github.com/redis-rb/redis-cluster-client/actions/runs/31939179365) | `test_cluster_state` | `cluster_controller.rb:124` `CLUSTER SETSLOT ... IMPORTING` |
| [31689893395](https://github.com/redis-rb/redis-cluster-client/actions/runs/31689893395), [31644309903](https://github.com/redis-rb/redis-cluster-client/actions/runs/31644309903) | `test_cluster_scale` | `cluster_controller.rb:158` `CLUSTER SETSLOT ... NODE` |
| [30696231803](https://github.com/redis-rb/redis-cluster-client/actions/runs/30696231803) | `test_cluster_broken` | `cluster_controller.rb:101` `CLUSTER FAILOVER TAKEOVER`, one line below the `wait_replication_delay` call |

## Cause

`swap_timeout` restored the original read timeout only on the happy path:

```ruby
regular_timeout = client.read_timeout
updater.call(client, timeout)
result = yield client
updater.call(client, regular_timeout)  # skipped when the block raises
result
```

`wait_replication_delay` swallows the error with `rescue ::RedisClient::ConnectionError` (`ReadTimeoutError` is a subclass of it), so nothing fails at that moment. The client keeps `read_timeout = 0.1` forever, and because the value is written to `client.config` as well, even a reconnection keeps it. Every subsequent `call_once` on that client then runs with a 0.1 second read timeout and dies far away from the real cause.

The block can raise in a few ordinary ways on a loaded runner:

- `primary_client?` issues `ROLE` through `call_once`, so it runs with the shortened 0.1 second timeout. `blocking_call` passes its own timeout down to `RubyConnection#read`, so the swap only ever affected this `ROLE` call.
- A node paused by `test_against_cluster_broken` raises `ConnectionError`.
- `WAIT` can hit its client side timeout, since `server_side_timeout = timeout_msec - 100` leaves only 100 ms of headroom.

The `test_cluster_scale` job is the clearest evidence: its controller is built with `timeout: 30.0`, yet the error says `Waited 0.1 seconds`. `0.1` appears nowhere else in the code.

## Fix

Restore the timeout in an `ensure` clause in both helpers, the same way `RedisClient::Cluster::Command.load` and `RedisClient::Cluster::Node#refetch_node_info_list` already do. `test/testing_helper.rb` has the same bug, so it is fixed together.

This is the minimal fix. Two related weak points are left alone for now:

- The 0.1 second swap in `wait_replication_delay` no longer breaks anything, but it still only shortens the `ROLE` call, and when that call times out the `WAIT` is silently skipped for that node.
- The 100 ms margin between the client side and server side `WAIT` timeouts is tight compared to the `TEST_TIMEOUT_SEC + 1.0` margin the test files use.

## Verification

- `bundle exec rake test` — 459 runs, 57003 assertions, 0 failures, 0 errors
- `TEST_CLASS_PATTERN=PrimaryOnly bundle exec rake test_cluster_state` — 6 runs, 48 assertions, 0 failures, 0 errors
- `bundle exec rubocop` on both files — no offenses
- Direct check of the helper: after a block that raises, `read_timeout` and `config` are back to the original value instead of staying at `0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
