### PR TITLE
fix: coerce non-redirected results within redirections

### DIFF
--- a/lib/redis_client/cluster/pipeline.rb
+++ b/lib/redis_client/cluster/pipeline.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'set'
 require 'redis_client'
 require 'redis_client/cluster/errors'
 require 'redis_client/cluster/noop_command_builder'
@@ -43,6 +44,19 @@ class RedisClient
 
         def get_block(inner_index)
           @blocks.is_a?(Array) ? @blocks[inner_index] : nil
+        end
+
+        def coerce_except!(replies, indices)
+          return replies unless @blocks.is_a?(Array)
+
+          skipped = Set.new(indices)
+          @blocks.each_with_index do |block, index|
+            next if block.nil? || skipped.include?(index)
+
+            replies[index] = block.call(replies[index])
+          end
+
+          replies
         end
       end
 
@@ -209,6 +223,7 @@ class RedisClient
 
           all_replies ||= Array.new(@size)
           pipeline = @pipelines[node_key]
+          pipeline.coerce_except!(v.replies, v.indices)
           v.indices.each { |i| v.replies[i] = handle_redirection(v.replies[i], pipeline, i) }
           pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
         end
@@ -217,7 +232,9 @@ class RedisClient
           raise v.first_exception if v.first_exception
 
           all_replies ||= Array.new(@size)
-          @pipelines[node_key].outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
+          pipeline = @pipelines[node_key]
+          pipeline._coerce!(v.replies)
+          pipeline.outer_indices.each_with_index { |outer, inner| all_replies[outer] = v.replies[inner] }
         end
 
         all_replies

--- a/test/redis_client/test_cluster.rb
+++ b/test/redis_client/test_cluster.rb
@@ -208,6 +208,31 @@ class RedisClient
         results.each_with_index { |got, i| assert_equal(i.to_s, got) }
       end
 
+      def test_pipelined_with_redirection
+        keys = Array.new(100) { |i| "key#{i}" }
+        @client.pipelined { |pipeline| keys.each { |key| pipeline.call('SET', key, key) } }
+        wait_for_replication
+
+        router = @client.instance_variable_get(:@router)
+        node = router.instance_variable_get(:@node)
+        grouped = keys.group_by { |key| router.find_node_key_by_key(key, primary: true) }
+        assert_operator(grouped.size, :>=, 2, 'Case: the keys should be spread over multiple primaries')
+
+        (_, moved_keys), (host_node_key, host_keys) = grouped.sort_by(&:first).first(2)
+        moved_key = moved_keys.first
+        slot = ::RedisClient::Cluster::KeySlotConverter.convert(moved_key)
+        node.update_slot(slot, host_node_key)
+        assert_equal(host_node_key, router.find_node_key_by_key(moved_key, primary: true), 'Case: a stale slot mapping')
+
+        keys_in_pipeline = [moved_key] + host_keys
+        got = @client.pipelined do |pipeline|
+          keys_in_pipeline.each { |key| pipeline.call('GET', key) { |reply| { key => reply } } }
+        end
+
+        want = keys_in_pipeline.map { |key| { key => key } }
+        assert_equal(want, got)
+      end
+
       def test_transaction_with_single_key
         got = @client.multi do |t|
           t.call('SET', 'counter', '0')


### PR DESCRIPTION
When a command is routed to a node that hits at least one redirection, results from redirected commands are correctly coerced (thru `handle_redirection`), while results from those that aren't never are (!). Coerce them.

We also need to do this when stale cluster state was noted, since the StaleClusterState raise skips `send_pipeline`'s coercion just the same.

We encountered this at GitLab; see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/250685. The test reproduces the condition by pointing one slot at the wrong primary. We make sure the other keys are actually on `host_node_key`, since the bug doesn't present if every command is handled by `handle_redirection`.
