### PR TITLE
chore: pass the request timeout to valkey client in milliseconds

### DIFF
--- a/test/ips_pipeline.rb
+++ b/test/ips_pipeline.rb
@@ -103,7 +103,8 @@ module IpsPipeline
   def make_valkey_client
     ::Valkey.new(
       nodes: [{ host: TEST_REDIS_HOST, port: TEST_REDIS_PORT }],
-      timeout: TEST_TIMEOUT_SEC,
+      # NOTE: valkey-rb passes this straight to the request timeout of GLIDE, which is in milliseconds.
+      timeout: (TEST_TIMEOUT_SEC * 1000).to_i,
       cluster_mode: true,
       protocol: 3
     )

--- a/test/ips_single.rb
+++ b/test/ips_single.rb
@@ -95,7 +95,8 @@ module IpsSingle
   def make_valkey_client
     ::Valkey.new(
       nodes: [{ host: TEST_REDIS_HOST, port: TEST_REDIS_PORT }],
-      timeout: TEST_TIMEOUT_SEC,
+      # NOTE: valkey-rb passes this straight to the request timeout of GLIDE, which is in milliseconds.
+      timeout: (TEST_TIMEOUT_SEC * 1000).to_i,
       cluster_mode: true,
       protocol: 3
     )


### PR DESCRIPTION
## Problem

The scheduled `IPS` job fails intermittently in the `valkey` report of `test/ips_pipeline.rb` ([example run](https://github.com/redis-rb/redis-cluster-client/actions/runs/32954688060/job/98133646623)):

```
Error executing command: timed out
valkey-rb-1.0.0/lib/valkey.rb:158:in 'Valkey#convert_response': timed out (Valkey::TimeoutError)
	from valkey-rb-1.0.0/lib/valkey.rb:112:in 'Valkey#send_batch_commands'
	from valkey-rb-1.0.0/lib/valkey.rb:33:in 'Valkey#pipelined'
	from test/ips_pipeline.rb:50:in 'block (2 levels) in IpsPipeline.run'
```

## Cause

`Valkey#initialize` hands the `timeout` option straight to the `request_timeout` field of the GLIDE connection request, and that field is a `uint32` in milliseconds:

```ruby
# valkey-rb-1.0.0/lib/valkey.rb
request_timeout = options[:timeout] || 5.0
# ...
request_params = { ..., request_timeout: request_timeout, ... }
```

(`connect_timeout` is converted with `* 1000` right below it, `timeout` is not.)

So `timeout: TEST_TIMEOUT_SEC` truncated `5.0` to `5` and gave the valkey client a **5 ms** request timeout instead of 5 seconds. A pipeline of 100 keys usually takes 0.6-2 ms, so it fitted in the budget most of the time and only blew up on a loaded runner.

Measured locally against `compose.yaml` with `redis:8`, timing only the blocking FFI call for a 20,000 command batch:

| `timeout:` | result |
| --- | --- |
| `5.0` | 3/3 `Valkey::TimeoutError` |
| `25` | 2/3 `Valkey::TimeoutError` |
| `50` | 3/3 OK |
| `250` | 3/3 OK |

If the unit were seconds, `5.0` would be the most generous of the four.

## Fix

Pass the timeout in milliseconds in both benchmark scripts. No library code is touched.